### PR TITLE
Fix repeated Google sync scheduling

### DIFF
--- a/front/src/screens/ConfigScreen.tsx
+++ b/front/src/screens/ConfigScreen.tsx
@@ -419,6 +419,10 @@ export default function ConfigScreen() {
     const unsubscribe = subscribeCalendarAccounts((list) => {
       setAccounts(sortAccounts(list));
       list.forEach((account) => {
+        if (registered.has(account.id)) {
+          refreshAccountSnapshot(account);
+          return;
+        }
         registerCalendarAccount(account);
         registered.add(account.id);
       });

--- a/front/src/services/calendarSyncManager.ts
+++ b/front/src/services/calendarSyncManager.ts
@@ -111,11 +111,25 @@ const startInterval = (accountId: string) => {
 export const registerCalendarAccount = (account: CalendarAccount) => {
   const existing = runners.get(account.id);
   if (existing) {
+    const previousAccount = existing.account;
     existing.account = account;
-    clearRunnerTimers(existing);
-    if (isAutoSyncEnabled(account)) {
+
+    const wasAutoSyncEnabled = isAutoSyncEnabled(previousAccount);
+    const isAutoSyncCurrentlyEnabled = isAutoSyncEnabled(account);
+
+    if (!isAutoSyncCurrentlyEnabled) {
+      clearRunnerTimers(existing);
+      return;
+    }
+
+    if (!wasAutoSyncEnabled && isAutoSyncCurrentlyEnabled) {
       startInterval(account.id);
       scheduleImmediateSync(account.id, 1_000);
+      return;
+    }
+
+    if (!existing.timer) {
+      startInterval(account.id);
     }
     return;
   }


### PR DESCRIPTION
## Summary
- prevent calendar store updates from re-registering already tracked accounts
- ensure existing sync runners keep their timers unless auto sync is toggled back on

## Testing
- npm test -- --watchAll=false *(fails: Jest cannot parse ESM modules from expo-font)*

------
https://chatgpt.com/codex/tasks/task_e_68d5b011c688832fa57fbb3c35b1933f