### PR TITLE
Add dynamic Microsoft OAuth configuration support

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -27,6 +27,7 @@ Variáveis relevantes:
 - DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME: credenciais da base MySQL.
 - GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URIS: credenciais do app Google.
 - MICROSOFT_CLIENT_ID, MICROSOFT_CLIENT_SECRET, MICROSOFT_REDIRECT_URIS, MICROSOFT_TENANT_ID: credenciais do app Microsoft.
+- MICROSOFT_ORGANIZATIONS_TENANT: tenant usado para contas corporativas (padrão `organizations`).
 - MICROSOFT_ALLOWED_TENANTS: lista (separada por vírgula) de tenants permitidos para autenticação.
 
 3. Crie as tabelas necessárias executando a migration inicial (ajuste o usuário/senha conforme o seu ambiente):

--- a/back/src/config.ts
+++ b/back/src/config.ts
@@ -86,6 +86,8 @@ export const config = {
     clientId: process.env.MICROSOFT_CLIENT_ID ?? "",
     clientSecret: process.env.MICROSOFT_CLIENT_SECRET ?? "",
     tenantId: (process.env.MICROSOFT_TENANT_ID ?? "common").trim() || "common",
+    organizationsTenant:
+      (process.env.MICROSOFT_ORGANIZATIONS_TENANT ?? "organizations").trim() || "organizations",
     redirectUris: parseRedirectUris(process.env.MICROSOFT_REDIRECT_URIS ?? ""),
     scopes: parseScopes(process.env.MICROSOFT_SCOPES ?? ""),
     allowedTenants: parseList(process.env.MICROSOFT_ALLOWED_TENANTS ?? ""),

--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -12,6 +12,22 @@ app.use(express.json());
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", timestamp: new Date().toISOString() });
 });
+
+app.get("/oauth/config", (_req, res) => {
+  res.json({
+    google: {
+      clientId: config.google.clientId || null,
+    },
+    microsoft: {
+      clientId: config.microsoft.clientId || null,
+      defaultTenant: config.microsoft.tenantId || null,
+      organizationsTenant: config.microsoft.organizationsTenant || null,
+      scopes: config.microsoft.scopes,
+      redirectUris: config.microsoft.redirectUris,
+      allowedTenants: config.microsoft.allowedTenants,
+    },
+  });
+});
 type OAuthExchangeRequest = {
   code?: string;
   redirectUri?: string;

--- a/back/src/outlookService.ts
+++ b/back/src/outlookService.ts
@@ -21,7 +21,7 @@ export type OutlookTokenResponse = {
   [key: string]: unknown;
 };
 
-const sanitizeTenantId = (value: string | undefined) => {
+const sanitizeTenantId = (value: string | null | undefined) => {
   if (!value) {
     return undefined;
   }

--- a/front/src/services/oauthConfig.ts
+++ b/front/src/services/oauthConfig.ts
@@ -1,0 +1,64 @@
+import { buildApiUrl } from "../config/api";
+import {
+  getOutlookOAuthConfig,
+  OutlookOAuthConfig,
+  updateOutlookOAuthConfig,
+} from "../config/outlookOAuth";
+
+type OAuthConfigResponse = {
+  microsoft?: {
+    clientId?: string | null;
+    defaultTenant?: string | null;
+    organizationsTenant?: string | null;
+    scopes?: string[] | null;
+  } | null;
+};
+
+const extractMicrosoftOverrides = (
+  payload: OAuthConfigResponse["microsoft"]
+): Partial<OutlookOAuthConfig> => {
+  if (!payload) {
+    return {};
+  }
+
+  const overrides: Partial<OutlookOAuthConfig> = {};
+
+  if (typeof payload.clientId === "string") {
+    overrides.clientId = payload.clientId;
+  }
+
+  if (typeof payload.defaultTenant === "string") {
+    overrides.defaultTenant = payload.defaultTenant;
+  }
+
+  if (typeof payload.organizationsTenant === "string") {
+    overrides.organizationsTenant = payload.organizationsTenant;
+  }
+
+  if (Array.isArray(payload.scopes)) {
+    overrides.scopes = payload.scopes
+      .map((scope) => (typeof scope === "string" ? scope.trim() : ""))
+      .filter((scope): scope is string => Boolean(scope));
+  }
+
+  return overrides;
+};
+
+export const loadRemoteOAuthConfig = async (): Promise<{
+  microsoft: OutlookOAuthConfig | null;
+}> => {
+  const response = await fetch(buildApiUrl("/oauth/config"));
+  if (!response.ok) {
+    const message = await response.text().catch(() => "Nao foi possivel carregar configuracao OAuth");
+    throw new Error(message || "Nao foi possivel carregar configuracao OAuth");
+  }
+
+  const data = (await response.json()) as OAuthConfigResponse;
+  if (data?.microsoft) {
+    const overrides = extractMicrosoftOverrides(data.microsoft);
+    const config = updateOutlookOAuthConfig(overrides);
+    return { microsoft: config };
+  }
+
+  return { microsoft: getOutlookOAuthConfig() };
+};

--- a/front/src/services/providers/outlookSync.ts
+++ b/front/src/services/providers/outlookSync.ts
@@ -10,12 +10,11 @@ import {
 } from "../calendarAccountsStore";
 import { persistProviderTokens } from "../calendarProviderActions";
 import { buildApiUrl } from "../../config/api";
-import { OUTLOOK_OAUTH_CONFIG } from "../../config/outlookOAuth";
+import { getOutlookOAuthConfig } from "../../config/outlookOAuth";
 
 const TOKEN_ENDPOINT = (tenant: string) =>
   `https://login.microsoftonline.com/${tenant}/oauth2/v2.0/token`;
 const CALENDAR_VIEW_ENDPOINT = "https://graph.microsoft.com/v1.0/me/calendarview";
-const DEFAULT_TENANT = OUTLOOK_OAUTH_CONFIG.defaultTenant || "common";
 const DEFAULT_DIFFICULTY = "Media";
 
 const diferencaEmMinutos = (inicio?: string | null, fim?: string | null) => {
@@ -42,20 +41,26 @@ const normalizarIso = (value?: string | null) => {
   return date.toISOString();
 };
 
+const resolveDefaultTenant = () => {
+  const config = getOutlookOAuthConfig();
+  return config.defaultTenant || "common";
+};
+
 const resolveTenant = (account: CalendarAccount) => {
   if (account.tenantId) {
     return account.tenantId;
   }
-  return DEFAULT_TENANT;
+  return resolveDefaultTenant();
 };
 
 const refreshAccessTokenLocally = async (account: CalendarAccount) => {
-  const clientId = account.clientId ?? OUTLOOK_OAUTH_CONFIG.clientId;
+  const config = getOutlookOAuthConfig();
+  const clientId = account.clientId ?? config.clientId;
   if (!clientId) {
     throw new Error("Client ID da Microsoft nao configurado para atualizar token.");
   }
 
-  const scopes = OUTLOOK_OAUTH_CONFIG.scopes.join(" ");
+  const scopes = config.scopes.join(" ");
   const payload = new URLSearchParams({
     client_id: clientId,
     grant_type: "refresh_token",


### PR DESCRIPTION
## Summary
- expose a public `/oauth/config` endpoint that surfaces configured Google and Microsoft OAuth metadata
- extend Microsoft backend configuration with the organizations tenant setting and tolerate nullable tenant ids
- load Microsoft OAuth settings from the backend on the frontend, caching them for auth flows and refresh logic
- update Outlook sync utilities to use the live configuration and document the new environment variable

## Testing
- `npm run build`
- `npx tsc --noEmit` *(fails: existing type errors in database.ts, ConfigScreen.tsx and outlookSync.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d691ece8cc832f99ad2a1fb4dbd0cc