### PR TITLE
Refine auth redirect URI handling

### DIFF
--- a/front/src/screens/ConfigScreen.tsx
+++ b/front/src/screens/ConfigScreen.tsx
@@ -138,6 +138,7 @@ const sortAccounts = (list: CalendarAccount[]) =>
   });
 
 export default function ConfigScreen() {
+  const useProxy = Platform.OS !== "web";
   const [accounts, setAccounts] = useState<CalendarAccount[]>([]);
   const [loading, setLoading] = useState(true);
   const [importModalVisible, setImportModalVisible] = useState(false);
@@ -200,8 +201,8 @@ export default function ConfigScreen() {
       const { origin, pathname } = window.location;
       return `${origin}${pathname}`;
     }
-    return AuthSession.makeRedirectUri();
-  }, []);
+    return AuthSession.makeRedirectUri({ useProxy });
+  }, [useProxy]);
 
   useEffect(() => {
     let active = true;
@@ -552,7 +553,7 @@ export default function ConfigScreen() {
       setAuthContext(context);
       setConnectingProvider("google");
       await promptGoogleAsync({
-        useProxy: Platform.OS !== "web",
+        useProxy,
         windowName: "coach-google-auth",
       }).catch((error) => {
         setConnectingProvider(null);
@@ -569,7 +570,7 @@ export default function ConfigScreen() {
     setAuthContext(context);
     setConnectingProvider("outlook");
     await promptOutlookAsync({
-      useProxy: Platform.OS !== "web",
+      useProxy,
       windowName: "coach-outlook-auth",
     }).catch((error) => {
       setConnectingProvider(null);


### PR DESCRIPTION
## Summary
- extract a reusable `useProxy` flag in `ConfigScreen`
- ensure redirect URI memoization honours the proxy flag and reuse across requests
- use the shared proxy flag when initiating Google and Outlook auth flows

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6a61ab988832f9f56b35b6a80a61d