### PR TITLE
Handle cancellation of external auth modals

### DIFF
--- a/front/src/screens/ConfigScreen.tsx
+++ b/front/src/screens/ConfigScreen.tsx
@@ -552,13 +552,22 @@ export default function ConfigScreen() {
       context.clientId = clientId;
       setAuthContext(context);
       setConnectingProvider("google");
-      await promptGoogleAsync({
-        useProxy,
-        windowName: "coach-google-auth",
-      }).catch((error) => {
+      try {
+        const result = await promptGoogleAsync({
+          useProxy,
+          windowName: "coach-google-auth",
+        });
+        if (result?.type !== "success") {
+          if (result?.type === "error" && typeof result.error === "string" && result.error.trim().length > 0) {
+            setErrorMessage(result.error);
+          }
+          setConnectingProvider(null);
+          setAuthContext(null);
+        }
+      } catch (error: any) {
         setConnectingProvider(null);
         setErrorMessage(error?.message ?? "Nao foi possivel iniciar o consentimento do Google.");
-      });
+      }
       return;
     }
 
@@ -569,13 +578,22 @@ export default function ConfigScreen() {
 
     setAuthContext(context);
     setConnectingProvider("outlook");
-    await promptOutlookAsync({
-      useProxy,
-      windowName: "coach-outlook-auth",
-    }).catch((error) => {
+    try {
+      const result = await promptOutlookAsync({
+        useProxy,
+        windowName: "coach-outlook-auth",
+      });
+      if (result?.type !== "success") {
+        if (result?.type === "error" && typeof result.error === "string" && result.error.trim().length > 0) {
+          setErrorMessage(result.error);
+        }
+        setConnectingProvider(null);
+        setAuthContext(null);
+      }
+    } catch (error: any) {
       setConnectingProvider(null);
       setErrorMessage(error?.message ?? "Nao foi possivel iniciar o consentimento da Microsoft.");
-    });
+    }
   }, [
     outlookOAuthConfig,
     promptGoogleAsync,


### PR DESCRIPTION
## Summary
- reset the loading state when Google or Outlook authentication modals close without completing
- surface prompt errors so the user receives feedback when the external modal fails

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d6a765ce34832f972525b726af6f42