### PR TITLE
Add calendar categories and soft delete tasks

### DIFF
--- a/front/src/constants/calendarCategories.ts
+++ b/front/src/constants/calendarCategories.ts
@@ -1,0 +1,46 @@
+export type CalendarCategoryKey = "personal" | "work";
+
+export type CalendarCategory = {
+  key: CalendarCategoryKey;
+  color: string;
+  label: string;
+};
+
+export const CALENDAR_CATEGORIES: CalendarCategory[] = [
+  {
+    key: "personal",
+    color: "#2a9d8f",
+    label: "Agenda pessoal",
+  },
+  {
+    key: "work",
+    color: "#264653",
+    label: "Agenda de trabalho",
+  },
+];
+
+export const DEFAULT_CALENDAR_CATEGORY = CALENDAR_CATEGORIES[0];
+
+export const normalizeCalendarColor = (color?: string | null) => {
+  if (typeof color === "string" && color.trim().length > 0) {
+    return color.trim().toLowerCase();
+  }
+  return DEFAULT_CALENDAR_CATEGORY.color;
+};
+
+export const findCalendarCategoryByColor = (color?: string | null) => {
+  if (typeof color !== "string" || color.trim().length === 0) {
+    return DEFAULT_CALENDAR_CATEGORY;
+  }
+  const normalized = color.trim().toLowerCase();
+  return (
+    CALENDAR_CATEGORIES.find(
+      (category) => category.color.toLowerCase() === normalized
+    ) ?? null
+  );
+};
+
+export const getCalendarCategoryLabel = (color?: string | null) => {
+  const category = findCalendarCategoryByColor(color);
+  return category ? category.label : "Agenda";
+};

--- a/front/src/screens/AgendaScreen.tsx
+++ b/front/src/screens/AgendaScreen.tsx
@@ -1,4 +1,4 @@
-﻿import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   View,
   Text,
@@ -9,6 +9,7 @@ import {
 import { Evento, salvarEvento, listarEventos, atualizarEvento } from "../database";
 import TaskModal from "../components/TaskModal";
 import { subscribeCalendarAccounts } from "../services/calendarAccountsStore";
+import { DEFAULT_CALENDAR_CATEGORY, normalizeCalendarColor } from "../constants/calendarCategories";
 
 type EventoAgenda = Evento;
 
@@ -366,7 +367,9 @@ export default function AgendaScreen() {
               ))}
 
               {eventosDiaAtual.map((ev) => {
-                const corBase = ev.conflict ? "#e63946" : ev.cor || "#2a9d8f";
+                const corBase = ev.conflict
+                  ? "#e63946"
+                  : normalizeCalendarColor(ev.cor ?? DEFAULT_CALENDAR_CATEGORY.color);
                 const altura = Math.max(
                   (ev.endMin - ev.startMin) * MINUTE_HEIGHT,
                   DURACAO_MINIMA * MINUTE_HEIGHT
@@ -516,7 +519,7 @@ export default function AgendaScreen() {
                       {eventosDia.map((ev) => {
                         const corBase = ev.conflict
                           ? "#e63946"
-                          : ev.cor || "#2a9d8f";
+                          : normalizeCalendarColor(ev.cor ?? DEFAULT_CALENDAR_CATEGORY.color);
                         const altura = Math.max(
                           (ev.endMin - ev.startMin) * MINUTE_HEIGHT,
                           DURACAO_MINIMA * MINUTE_HEIGHT

--- a/front/src/services/calendarAccountsStore.ts
+++ b/front/src/services/calendarAccountsStore.ts
@@ -1,4 +1,5 @@
-﻿import AsyncStorage from "@react-native-async-storage/async-storage";
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { DEFAULT_CALENDAR_CATEGORY, normalizeCalendarColor } from "../constants/calendarCategories";
 import { CalendarAccount } from "../types/calendar";
 
 const STORAGE_KEY = "@coach/calendarAccounts";
@@ -18,7 +19,7 @@ const notify = () => {
 
 const normalizeAccount = (account: CalendarAccount): CalendarAccount => ({
   ...account,
-  color: (account.color || "#2a9d8f").toLowerCase(),
+  color: normalizeCalendarColor(account.color ?? DEFAULT_CALENDAR_CATEGORY.color),
   autoSyncEnabled: account.autoSyncEnabled ?? true,
   lastSync: account.lastSync ?? null,
   status: account.status ?? "idle",
@@ -123,7 +124,7 @@ export const updateCalendarAccountColor = async (accountId: string, color: strin
   if (index < 0) {
     return;
   }
-  const normalized = color.toLowerCase();
+  const normalized = normalizeCalendarColor(color);
   accounts[index] = { ...accounts[index], color: normalized };
   await persist();
   notify();


### PR DESCRIPTION
## Summary
- add shared calendar category helpers so calendar accounts normalize to personal or work colors
- update the configuration flow to classify each integration with one of the two categories and display the label on account cards
- propagate the agenda colors into task cards and agenda events while soft-deleting tasks instead of removing rows

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d6b405f1ec832f9418fef2576d282d