### PR TITLE
Ensure Microsoft OAuth uses delegated scopes

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -27,6 +27,7 @@ Variáveis relevantes:
 - DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME: credenciais da base MySQL.
 - GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URIS: credenciais do app Google.
 - MICROSOFT_CLIENT_ID, MICROSOFT_CLIENT_SECRET, MICROSOFT_REDIRECT_URIS, MICROSOFT_TENANT_ID: credenciais do app Microsoft.
+- MICROSOFT_SCOPES: escopos adicionais para o login Microsoft (por padrão solicitamos permissões delegadas como `Calendars.ReadWrite`).
 - MICROSOFT_ORGANIZATIONS_TENANT: tenant usado para contas corporativas (padrão `organizations`).
 - MICROSOFT_ALLOWED_TENANTS: lista (separada por vírgula) de tenants permitidos para autenticação.
 
@@ -84,7 +85,7 @@ Resposta (resumo):
 `
 
 ### POST /oauth/outlook/exchange
-Fluxo idêntico ao do Google, porém usando o endpoint da Microsoft. Aceita parâmetros opcionais como 	enantId, scopes e color.
+Fluxo idêntico ao do Google, porém usando o endpoint da Microsoft com permissões delegadas (Authorization Code Flow). Aceita parâmetros opcionais como tenantId, scopes e color.
 
 ### GET /accounts
 Lista todas as contas de calendário cadastradas no banco.

--- a/back/src/outlookService.ts
+++ b/back/src/outlookService.ts
@@ -61,7 +61,7 @@ const ensureScopes = (scopes: string[] | undefined) => {
     ...config.microsoft.scopes,
     ...(Array.isArray(scopes) ? scopes : []),
     "offline_access",
-    "https://graph.microsoft.com/Calendars.ReadWrite",
+    "Calendars.ReadWrite",
     "openid",
     "profile",
     "email",

--- a/front/src/config/outlookOAuth.ts
+++ b/front/src/config/outlookOAuth.ts
@@ -27,7 +27,7 @@ const requiredScopes = [
   "openid",
   "profile",
   "email",
-  "https://graph.microsoft.com/Calendars.ReadWrite",
+  "Calendars.ReadWrite",
 ];
 
 const sanitizeTenant = (value: string | null | undefined, fallback: string) => {


### PR DESCRIPTION
## Summary
- update the Outlook OAuth helper to request delegated Microsoft Graph calendar scopes by default
- align the Expo configuration to require the same delegated Calendars.ReadWrite scope
- document the delegated Outlook flow and configurable scopes in the backend README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d6df7dde18832fb4aed07809a46c17