### PR TITLE
Support Microsoft personal accounts for Outlook calendar sync

### DIFF
--- a/back/README.md
+++ b/back/README.md
@@ -26,10 +26,10 @@ Variáveis relevantes:
 
 - DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME: credenciais da base MySQL.
 - GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_REDIRECT_URIS: credenciais do app Google.
-- MICROSOFT_CLIENT_ID, MICROSOFT_CLIENT_SECRET, MICROSOFT_REDIRECT_URIS, MICROSOFT_TENANT_ID: credenciais do app Microsoft.
+- MICROSOFT_CLIENT_ID, MICROSOFT_CLIENT_SECRET, MICROSOFT_REDIRECT_URIS, MICROSOFT_TENANT_ID: credenciais do app Microsoft. Por padrão usamos o tenant `consumers`, voltado para contas pessoais (Outlook.com, Hotmail, Live, etc.).
 - MICROSOFT_SCOPES: escopos adicionais para o login Microsoft (por padrão solicitamos permissões delegadas como `Calendars.ReadWrite`).
 - MICROSOFT_ORGANIZATIONS_TENANT: tenant usado para contas corporativas (padrão `organizations`).
-- MICROSOFT_ALLOWED_TENANTS: lista (separada por vírgula) de tenants permitidos para autenticação.
+- MICROSOFT_ALLOWED_TENANTS: lista (separada por vírgula) de tenants permitidos para autenticação. Caso não seja informado, permitimos automaticamente o tenant pessoal (`consumers`) e o corporativo configurado.
 
 3. Crie as tabelas necessárias executando a migration inicial (ajuste o usuário/senha conforme o seu ambiente):
 

--- a/back/src/config.ts
+++ b/back/src/config.ts
@@ -85,16 +85,26 @@ export const config = {
     clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
     redirectUris: parseRedirectUris(process.env.GOOGLE_REDIRECT_URIS ?? ""),
   },
-  microsoft: {
-    clientId: process.env.MICROSOFT_CLIENT_ID ?? "",
-    clientSecret: process.env.MICROSOFT_CLIENT_SECRET ?? "",
-    tenantId: (process.env.MICROSOFT_TENANT_ID ?? "common").trim() || "common",
-    organizationsTenant:
-      (process.env.MICROSOFT_ORGANIZATIONS_TENANT ?? "organizations").trim() || "organizations",
-    redirectUris: parseRedirectUris(process.env.MICROSOFT_REDIRECT_URIS ?? ""),
-    scopes: parseScopes(process.env.MICROSOFT_SCOPES ?? ""),
-    allowedTenants: parseList(process.env.MICROSOFT_ALLOWED_TENANTS ?? ""),
-  },
+  microsoft: (() => {
+    const defaultTenant = (process.env.MICROSOFT_TENANT_ID ?? "consumers").trim() || "consumers";
+    const organizationsTenant =
+      (process.env.MICROSOFT_ORGANIZATIONS_TENANT ?? "organizations").trim() || "organizations";
+    const explicitAllowed = parseList(process.env.MICROSOFT_ALLOWED_TENANTS ?? "");
+    const allowedTenants =
+      explicitAllowed.length > 0
+        ? explicitAllowed
+        : Array.from(new Set([defaultTenant, organizationsTenant]));
+
+    return {
+      clientId: process.env.MICROSOFT_CLIENT_ID ?? "",
+      clientSecret: process.env.MICROSOFT_CLIENT_SECRET ?? "",
+      tenantId: defaultTenant,
+      organizationsTenant,
+      redirectUris: parseRedirectUris(process.env.MICROSOFT_REDIRECT_URIS ?? ""),
+      scopes: parseScopes(process.env.MICROSOFT_SCOPES ?? ""),
+      allowedTenants,
+    };
+  })(),
 };
 
 if (!config.google.clientId || !config.google.clientSecret) {

--- a/front/src/config/outlookOAuth.ts
+++ b/front/src/config/outlookOAuth.ts
@@ -65,7 +65,7 @@ export type OutlookOAuthConfig = {
 
 const initialConfig: OutlookOAuthConfig = {
   clientId: process.env.EXPO_PUBLIC_MICROSOFT_CLIENT_ID ?? "",
-  defaultTenant: sanitizeTenant(process.env.EXPO_PUBLIC_MICROSOFT_DEFAULT_TENANT, "common"),
+  defaultTenant: sanitizeTenant(process.env.EXPO_PUBLIC_MICROSOFT_DEFAULT_TENANT, "consumers"),
   organizationsTenant: sanitizeTenant(
     process.env.EXPO_PUBLIC_MICROSOFT_ORGANIZATIONS_TENANT,
     "organizations"

--- a/front/src/screens/ConfigScreen.tsx
+++ b/front/src/screens/ConfigScreen.tsx
@@ -159,7 +159,7 @@ export default function ConfigScreen() {
         title: "Outlook.com",
         subtitle: "Conta pessoal",
         icon: "microsoft-outlook",
-        tenantId: outlookOAuthConfig.defaultTenant || "common",
+        tenantId: outlookOAuthConfig.defaultTenant || "consumers",
       },
       {
         id: "outlook-business",
@@ -266,6 +266,11 @@ export default function ConfigScreen() {
     [redirectUri]
   );
 
+  const resolvedTenantForDiscovery = useMemo(
+    () => (outlookOAuthConfig.defaultTenant || "consumers").trim() || "consumers",
+    [outlookOAuthConfig.defaultTenant]
+  );
+
   const outlookRequestConfig = useMemo(
     () => ({
       clientId: outlookOAuthConfig.clientId,
@@ -284,10 +289,10 @@ export default function ConfigScreen() {
 
   const outlookDiscovery = useMemo(
     () => ({
-      authorizationEndpoint: "https://login.microsoftonline.com/common/oauth2/v2.0/authorize",
-      tokenEndpoint: "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      authorizationEndpoint: `https://login.microsoftonline.com/${resolvedTenantForDiscovery}/oauth2/v2.0/authorize`,
+      tokenEndpoint: `https://login.microsoftonline.com/${resolvedTenantForDiscovery}/oauth2/v2.0/token`,
     }),
-    []
+    [resolvedTenantForDiscovery]
   );
 
   const [googleRequest, googleResponse, promptGoogleAsync] = Google.useAuthRequest(googleRequestOptions);
@@ -367,7 +372,7 @@ export default function ConfigScreen() {
 
       setConnectingProvider("outlook");
 
-      const tenantId = authContext.tenantId || outlookOAuthConfig.defaultTenant || "common";
+      const tenantId = authContext.tenantId || outlookOAuthConfig.defaultTenant || "consumers";
 
       const payload: Record<string, unknown> = {
         code,

--- a/front/src/services/providers/outlookSync.ts
+++ b/front/src/services/providers/outlookSync.ts
@@ -43,7 +43,7 @@ const normalizarIso = (value?: string | null) => {
 
 const resolveDefaultTenant = () => {
   const config = getOutlookOAuthConfig();
-  return config.defaultTenant || "common";
+  return config.defaultTenant || "consumers";
 };
 
 const resolveTenant = (account: CalendarAccount) => {


### PR DESCRIPTION
## Summary
- default the backend Microsoft OAuth configuration to the consumer tenant and relax allowed tenant defaults
- update the mobile client to request tokens against the consumer tenant endpoints by default
- document the new default behaviour for Microsoft personal account support

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d6e73db278832fb5d0254fad2d5d5b