### PR TITLE
Add read-only ICS calendar integration

### DIFF
--- a/back/migrations/002_add_ics_calendar.sql
+++ b/back/migrations/002_add_ics_calendar.sql
@@ -1,0 +1,8 @@
+ALTER TABLE calendar_accounts
+  MODIFY COLUMN provider ENUM("google", "outlook", "ics") NOT NULL;
+
+ALTER TABLE calendar_accounts
+  ADD COLUMN ics_url TEXT NULL AFTER refresh_token;
+
+ALTER TABLE calendar_events
+  MODIFY COLUMN provider ENUM("google", "outlook", "ics", "local") NOT NULL DEFAULT "local";

--- a/back/src/repositories/calendarAccountRepository.ts
+++ b/back/src/repositories/calendarAccountRepository.ts
@@ -2,7 +2,7 @@
 import { v4 as uuid } from "uuid";
 import { withConnection } from "../db";
 
-export type CalendarProvider = "google" | "outlook";
+export type CalendarProvider = "google" | "outlook" | "ics";
 
 export type CalendarAccountRecord = {
   id: string;
@@ -16,6 +16,7 @@ export type CalendarAccountRecord = {
   access_token: string | null;
   access_token_expires_at: Date | null;
   refresh_token: string | null;
+  ics_url: string | null;
   raw_payload: Record<string, unknown> | null;
   created_at: Date;
   updated_at: Date;
@@ -34,6 +35,7 @@ type UpsertAccountParams = {
   accessToken?: string | null;
   accessTokenExpiresAt?: Date | null;
   refreshToken?: string | null;
+  icsUrl?: string | null;
   rawPayload?: Record<string, unknown> | null;
 };
 
@@ -59,6 +61,7 @@ const mapRow = (row: DbCalendarAccount): CalendarAccountRecord => ({
   display_name: row.display_name,
   tenant_id: row.tenant_id,
   external_id: row.external_id,
+  ics_url: row.ics_url ?? null,
   access_token_expires_at: row.access_token_expires_at ? new Date(row.access_token_expires_at) : null,
   created_at: new Date(row.created_at),
   updated_at: new Date(row.updated_at),
@@ -110,6 +113,7 @@ export const calendarAccountRepository = {
                access_token = ?,
                access_token_expires_at = ?,
                refresh_token = ?,
+               ics_url = ?,
                raw_payload = ?,
                updated_at = CURRENT_TIMESTAMP
            WHERE id = ?`,
@@ -122,6 +126,7 @@ export const calendarAccountRepository = {
             params.accessToken ?? existing.access_token,
             params.accessTokenExpiresAt ?? existing.access_token_expires_at,
             params.refreshToken ?? existing.refresh_token,
+            params.icsUrl ?? existing.ics_url,
             params.rawPayload ? JSON.stringify(params.rawPayload) : existing.raw_payload,
             existing.id,
           ]
@@ -139,8 +144,8 @@ export const calendarAccountRepository = {
       await conn.query(
         `INSERT INTO calendar_accounts (
           id, provider, email, display_name, color, scope, tenant_id, external_id,
-          access_token, access_token_expires_at, refresh_token, raw_payload
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)` ,
+          access_token, access_token_expires_at, refresh_token, ics_url, raw_payload
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)` ,
         [
           id,
           params.provider,
@@ -153,6 +158,7 @@ export const calendarAccountRepository = {
           params.accessToken ?? null,
           params.accessTokenExpiresAt ?? null,
           params.refreshToken ?? null,
+          params.icsUrl ?? null,
           params.rawPayload ? JSON.stringify(params.rawPayload) : null,
         ]
       );

--- a/front/src/services/calendarAccountsStore.ts
+++ b/front/src/services/calendarAccountsStore.ts
@@ -32,6 +32,8 @@ const normalizeAccount = (account: CalendarAccount): CalendarAccount => ({
   calendarId: account.calendarId ?? (account.provider === "google" ? "primary" : null),
   tenantId: account.tenantId ?? null,
   externalId: account.externalId ?? null,
+  icsUrl: account.icsUrl ?? null,
+  readOnly: account.provider === "ics" ? true : account.readOnly ?? false,
 });
 
 export const initializeCalendarAccounts = async () => {

--- a/front/src/services/calendarSyncManager.ts
+++ b/front/src/services/calendarSyncManager.ts
@@ -5,6 +5,7 @@ import {
 } from "./calendarAccountsStore";
 import { syncGoogleAccount } from "./providers/googleSync";
 import { syncOutlookAccount } from "./providers/outlookSync";
+import { syncIcsAccount } from "./providers/icsSync";
 
 const AUTO_SYNC_INTERVAL = 5 * 60 * 1000;
 const IMMEDIATE_SYNC_DELAY = 3_000;
@@ -39,6 +40,10 @@ const performProviderSync = async (account: CalendarAccount) => {
   }
   if (account.provider === "outlook") {
     await syncOutlookAccount(account);
+    return;
+  }
+  if (account.provider === "ics") {
+    await syncIcsAccount(account);
     return;
   }
   throw new Error(`Provider "${account.provider}" nao suportado.`);

--- a/front/src/services/providers/icsSync.ts
+++ b/front/src/services/providers/icsSync.ts
@@ -1,0 +1,283 @@
+import { CalendarAccount } from "../../types/calendar";
+import {
+  Evento,
+  removerEventosSincronizados,
+  upsertEventoPorIcsUid,
+} from "../../database";
+import { updateCalendarAccountStatus } from "../calendarAccountsStore";
+
+const DEFAULT_DIFFICULTY = "Media";
+const DEFAULT_TYPE = "Calendário ICS";
+
+type ParsedIcsEvent = {
+  uid?: string;
+  summary?: string;
+  description?: string;
+  start?: string | null;
+  end?: string | null;
+  lastModified?: string | null;
+  status?: string | null;
+};
+
+type IcsProperty = {
+  name: string;
+  params: Record<string, string>;
+  value: string;
+};
+
+const unfoldIcsLines = (content: string): string[] => {
+  const rawLines = content.split(/\r?\n/);
+  const lines: string[] = [];
+
+  for (const rawLine of rawLines) {
+    if (!rawLine) {
+      if (lines.length === 0) {
+        continue;
+      }
+      lines.push("");
+      continue;
+    }
+
+    if (rawLine.startsWith(" ") || rawLine.startsWith("\t")) {
+      if (lines.length === 0) {
+        lines.push(rawLine.trimStart());
+        continue;
+      }
+      lines[lines.length - 1] += rawLine.slice(1);
+      continue;
+    }
+
+    lines.push(rawLine);
+  }
+
+  return lines;
+};
+
+const parseProperty = (line: string): IcsProperty | null => {
+  const separatorIndex = line.indexOf(":");
+  if (separatorIndex <= 0) {
+    return null;
+  }
+
+  const namePart = line.slice(0, separatorIndex);
+  const value = line.slice(separatorIndex + 1);
+  const [rawName, ...rawParams] = namePart.split(";");
+  const name = rawName.trim().toUpperCase();
+  const params: Record<string, string> = {};
+
+  rawParams.forEach((chunk) => {
+    const [rawKey, rawValue] = chunk.split("=");
+    if (!rawKey || !rawValue) {
+      return;
+    }
+    const key = rawKey.trim().toUpperCase();
+    const paramValue = rawValue.trim();
+    if (key) {
+      params[key] = paramValue;
+    }
+  });
+
+  return { name, params, value };
+};
+
+const unescapeText = (value: string): string =>
+  value
+    .replace(/\\n/gi, "\n")
+    .replace(/\\N/g, "\n")
+    .replace(/\\,/g, ",")
+    .replace(/\\;/g, ";")
+    .replace(/\\\\/g, "\\")
+    .trim();
+
+const parseDateValue = (value: string, params: Record<string, string>): string | null => {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const normalized = trimmed.replace(/\s+/g, "");
+  const match = normalized.match(/^(\d{4})(\d{2})(\d{2})(T(\d{2})(\d{2})(\d{2})(Z)?)?$/);
+  if (match) {
+    const year = Number(match[1]);
+    const month = Number(match[2]) - 1;
+    const day = Number(match[3]);
+
+    if (!match[4] || params.VALUE?.toUpperCase() === "DATE") {
+      const date = new Date(Date.UTC(year, month, day, 0, 0, 0));
+      return Number.isNaN(date.getTime()) ? null : date.toISOString();
+    }
+
+    const hour = Number(match[5]);
+    const minute = Number(match[6]);
+    const second = Number(match[7]);
+    const hasZ = match[8] === "Z";
+
+    if (hasZ) {
+      const date = new Date(Date.UTC(year, month, day, hour, minute, second));
+      return Number.isNaN(date.getTime()) ? null : date.toISOString();
+    }
+
+    const localDate = new Date(year, month, day, hour, minute, second);
+    if (!Number.isNaN(localDate.getTime())) {
+      return localDate.toISOString();
+    }
+
+    const utcFallback = new Date(Date.UTC(year, month, day, hour, minute, second));
+    return Number.isNaN(utcFallback.getTime()) ? null : utcFallback.toISOString();
+  }
+
+  const parsed = new Date(trimmed);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+};
+
+const parseIcsEvents = (content: string): ParsedIcsEvent[] => {
+  const lines = unfoldIcsLines(content);
+  const events: ParsedIcsEvent[] = [];
+  let current: ParsedIcsEvent | null = null;
+
+  for (const line of lines) {
+    if (!line) {
+      continue;
+    }
+
+    if (line.toUpperCase() === "BEGIN:VEVENT") {
+      current = {};
+      continue;
+    }
+
+    if (line.toUpperCase() === "END:VEVENT") {
+      if (current && current.uid) {
+        if ((current.status ?? "").toUpperCase() !== "CANCELLED") {
+          events.push(current);
+        }
+      }
+      current = null;
+      continue;
+    }
+
+    if (!current) {
+      continue;
+    }
+
+    const property = parseProperty(line);
+    if (!property) {
+      continue;
+    }
+
+    const { name, params, value } = property;
+    switch (name) {
+      case "UID":
+        current.uid = value.trim();
+        break;
+      case "SUMMARY":
+        current.summary = unescapeText(value);
+        break;
+      case "DESCRIPTION":
+        current.description = unescapeText(value);
+        break;
+      case "DTSTART":
+        current.start = parseDateValue(value, params);
+        break;
+      case "DTEND":
+        current.end = parseDateValue(value, params);
+        break;
+      case "LAST-MODIFIED":
+      case "DTSTAMP":
+        current.lastModified = parseDateValue(value, params) ?? current.lastModified ?? null;
+        break;
+      case "STATUS":
+        current.status = value.trim();
+        break;
+      default:
+        break;
+    }
+  }
+
+  return events;
+};
+
+const diferencaEmMinutos = (inicio?: string | null, fim?: string | null) => {
+  if (!inicio || !fim) {
+    return 0;
+  }
+  const inicioDate = new Date(inicio);
+  const fimDate = new Date(fim);
+  if (Number.isNaN(inicioDate.getTime()) || Number.isNaN(fimDate.getTime())) {
+    return 0;
+  }
+  const diff = Math.max(0, fimDate.getTime() - inicioDate.getTime());
+  return Math.round(diff / 60000);
+};
+
+const mapIcsToEvento = (item: ParsedIcsEvent, account: CalendarAccount): Evento | null => {
+  const inicioIso = item.start;
+  if (!inicioIso) {
+    return null;
+  }
+
+  const fimIso = item.end ?? inicioIso;
+  const tempoExecucao = Math.max(1, diferencaEmMinutos(inicioIso, fimIso));
+
+  return {
+    titulo: item.summary?.trim() || "Evento sem titulo",
+    observacao: item.description || undefined,
+    data: inicioIso,
+    tipo: DEFAULT_TYPE,
+    dificuldade: DEFAULT_DIFFICULTY,
+    tempoExecucao,
+    inicio: inicioIso,
+    fim: fimIso,
+    cor: account.color,
+    icsUid: item.uid,
+    updatedAt: item.lastModified ?? new Date().toISOString(),
+    provider: "ics",
+    accountId: account.id,
+    status: "ativo",
+  };
+};
+
+export const syncIcsAccount = async (account: CalendarAccount) => {
+  await updateCalendarAccountStatus(account.id, {
+    status: "syncing",
+    errorMessage: null,
+  });
+
+  if (!account.icsUrl) {
+    throw new Error("Conta ICS sem link configurado.");
+  }
+
+  const url = account.icsUrl.trim();
+  if (!url) {
+    throw new Error("Informe um link ICS válido para sincronizar.");
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`Falha ao carregar o arquivo ICS (${response.status}).`);
+  }
+
+  const content = await response.text();
+  if (!content.trim()) {
+    throw new Error("O arquivo ICS está vazio.");
+  }
+
+  const parsedEvents = parseIcsEvents(content);
+  const eventos: Evento[] = [];
+  for (const item of parsedEvents) {
+    const evento = mapIcsToEvento(item, account);
+    if (evento) {
+      eventos.push(evento);
+    }
+  }
+
+  await removerEventosSincronizados("ics", { accountId: account.id });
+  for (const evento of eventos) {
+    await upsertEventoPorIcsUid(evento);
+  }
+
+  await updateCalendarAccountStatus(account.id, {
+    status: "idle",
+    lastSync: new Date().toISOString(),
+    errorMessage: null,
+  });
+};

--- a/front/src/types/calendar.ts
+++ b/front/src/types/calendar.ts
@@ -1,4 +1,4 @@
-﻿export type CalendarProvider = "google" | "outlook";
+export type CalendarProvider = "google" | "outlook" | "ics";
 
 export type CalendarAccount = {
   id: string;
@@ -18,4 +18,6 @@ export type CalendarAccount = {
   lastSync?: string | null;
   status?: "idle" | "syncing" | "error";
   errorMessage?: string | null;
+  icsUrl?: string | null;
+  readOnly?: boolean;
 };


### PR DESCRIPTION
## Summary
- extend the calendar account schema and API to register read-only ICS links
- add an ICS option to the configuration screen with validation, UI, and sync wiring
- implement ICS file parsing, SQLite support, and sync flow for importing events

## Testing
- npm test -- --watch=false *(fails: expo dependencies require transform configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dabd7410ac832fbb71b26f73e60ce4