### PR TITLE
Handle pending sync before disconnecting calendar accounts

### DIFF
--- a/front/src/screens/ConfigScreen.tsx
+++ b/front/src/screens/ConfigScreen.tsx
@@ -517,7 +517,7 @@ export default function ConfigScreen() {
 
       [...registered].forEach((id) => {
         if (!list.some((account) => account.id === id)) {
-          unregisterCalendarAccount(id);
+          void unregisterCalendarAccount(id);
           registered.delete(id);
         }
       });
@@ -776,10 +776,10 @@ export default function ConfigScreen() {
       await fetch(buildApiUrl(`/accounts/${disconnectingAccount.id}`), {
         method: "DELETE",
       });
+      await unregisterCalendarAccount(disconnectingAccount.id);
       await removerEventosSincronizados(disconnectingAccount.provider, {
         accountId: disconnectingAccount.id,
       });
-      unregisterCalendarAccount(disconnectingAccount.id);
       await removeCalendarAccount(disconnectingAccount.id);
       setFeedbackMessage("Conta desconectada e tarefas marcadas como removidas.");
     } catch (error: any) {


### PR DESCRIPTION
## Summary
- track the current sync promise for each calendar account and block new schedules after unregistering
- wait for an ongoing sync to finish before removing an account and mark removals in the config screen

## Testing
- `npx tsc --noEmit` *(fails: pre-existing type errors in database and OAuth helpers)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc813ac34832f94e24c3be2931b1c