### PR TITLE
Add offline event sync integration

### DIFF
--- a/back/migrations/003_create_app_events.sql
+++ b/back/migrations/003_create_app_events.sql
@@ -1,0 +1,23 @@
+CREATE TABLE IF NOT EXISTS app_events (
+  id CHAR(36) NOT NULL,
+  title VARCHAR(512) NOT NULL,
+  notes TEXT NULL,
+  event_date TEXT NULL,
+  event_type VARCHAR(255) NOT NULL,
+  difficulty VARCHAR(255) NOT NULL,
+  duration_minutes INT NOT NULL DEFAULT 15,
+  start_at TEXT NULL,
+  end_at TEXT NULL,
+  color CHAR(7) NULL,
+  status VARCHAR(64) NOT NULL DEFAULT 'ativo',
+  provider VARCHAR(32) NOT NULL DEFAULT 'local',
+  account_id VARCHAR(255) NULL,
+  google_id VARCHAR(255) NULL,
+  outlook_id VARCHAR(255) NULL,
+  ics_uid VARCHAR(255) NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE INDEX IF NOT EXISTS idx_app_events_updated_at ON app_events(updated_at);

--- a/back/src/repositories/appEventRepository.ts
+++ b/back/src/repositories/appEventRepository.ts
@@ -1,0 +1,196 @@
+import { RowDataPacket } from "mysql2";
+import { withConnection } from "../db";
+
+export type AppEventSyncPayload = {
+  id: string;
+  title: string;
+  notes: string | null;
+  date: string | null;
+  type: string;
+  difficulty: string;
+  duration: number;
+  start: string | null;
+  end: string | null;
+  color: string | null;
+  status: string | null;
+  provider: string | null;
+  accountId: string | null;
+  googleId: string | null;
+  outlookId: string | null;
+  icsUid: string | null;
+  updatedAt: string;
+  createdAt: string | null;
+};
+
+type DbAppEvent = RowDataPacket & {
+  id: string;
+  title: string;
+  notes: string | null;
+  event_date: string | null;
+  event_type: string;
+  difficulty: string;
+  duration_minutes: number;
+  start_at: string | null;
+  end_at: string | null;
+  color: string | null;
+  status: string | null;
+  provider: string | null;
+  account_id: string | null;
+  google_id: string | null;
+  outlook_id: string | null;
+  ics_uid: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+const sanitizeString = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+const ensureDuration = (value: unknown, fallback = 15): number => {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return Math.max(1, Math.round(value));
+  }
+  if (typeof value === "string") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) {
+      return Math.max(1, Math.round(parsed));
+    }
+  }
+  return Math.max(1, Math.round(fallback));
+};
+
+const parseDate = (value: string | null | undefined): Date | null => {
+  if (!value) {
+    return null;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date;
+};
+
+const toSyncPayload = (row: DbAppEvent): AppEventSyncPayload => ({
+  id: row.id,
+  title: row.title,
+  notes: row.notes ?? null,
+  date: row.event_date ?? null,
+  type: row.event_type,
+  difficulty: row.difficulty,
+  duration: ensureDuration(row.duration_minutes),
+  start: row.start_at ?? null,
+  end: row.end_at ?? null,
+  color: row.color ?? null,
+  status: row.status ?? null,
+  provider: row.provider ?? null,
+  accountId: row.account_id ?? null,
+  googleId: row.google_id ?? null,
+  outlookId: row.outlook_id ?? null,
+  icsUid: row.ics_uid ?? null,
+  updatedAt: row.updated_at ? row.updated_at.toISOString() : new Date().toISOString(),
+  createdAt: row.created_at ? row.created_at.toISOString() : null,
+});
+
+export const appEventRepository = {
+  async listChangedSince(since: Date | null): Promise<AppEventSyncPayload[]> {
+    return withConnection(async (conn) => {
+      const query = since
+        ? "SELECT * FROM app_events WHERE updated_at > ? ORDER BY updated_at ASC"
+        : "SELECT * FROM app_events ORDER BY updated_at ASC";
+      const params: any[] = since ? [since] : [];
+      const [rows] = await conn.query<DbAppEvent[]>(query, params);
+      return rows.map(toSyncPayload);
+    });
+  },
+
+  async upsertMany(events: AppEventSyncPayload[]): Promise<void> {
+    if (events.length === 0) {
+      return;
+    }
+
+    await withConnection(async (conn) => {
+      await conn.beginTransaction();
+      try {
+        for (const event of events) {
+          const id = sanitizeString(event.id);
+          const title = sanitizeString(event.title) ?? "Evento";
+          const eventType = sanitizeString(event.type) ?? "Tarefa";
+          const difficulty = sanitizeString(event.difficulty) ?? "Media";
+          const notes = sanitizeString(event.notes ?? undefined);
+          const date = sanitizeString(event.date ?? undefined);
+          const start = sanitizeString(event.start ?? undefined);
+          const end = sanitizeString(event.end ?? undefined);
+          const color = sanitizeString(event.color ?? undefined);
+          const status = sanitizeString(event.status ?? undefined) ?? "ativo";
+          const provider = sanitizeString(event.provider ?? undefined) ?? "local";
+          const accountId = sanitizeString(event.accountId ?? undefined);
+          const googleId = sanitizeString(event.googleId ?? undefined);
+          const outlookId = sanitizeString(event.outlookId ?? undefined);
+          const icsUid = sanitizeString(event.icsUid ?? undefined);
+          const updatedAt = parseDate(event.updatedAt) ?? new Date();
+          const createdAt = parseDate(event.createdAt) ?? updatedAt;
+          const duration = ensureDuration(event.duration);
+
+          if (!id) {
+            continue;
+          }
+
+          await conn.query(
+            `INSERT INTO app_events (
+              id, title, notes, event_date, event_type, difficulty, duration_minutes,
+              start_at, end_at, color, status, provider, account_id, google_id,
+              outlook_id, ics_uid, created_at, updated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON DUPLICATE KEY UPDATE
+              title = IF(VALUES(updated_at) >= updated_at, VALUES(title), title),
+              notes = IF(VALUES(updated_at) >= updated_at, VALUES(notes), notes),
+              event_date = IF(VALUES(updated_at) >= updated_at, VALUES(event_date), event_date),
+              event_type = IF(VALUES(updated_at) >= updated_at, VALUES(event_type), event_type),
+              difficulty = IF(VALUES(updated_at) >= updated_at, VALUES(difficulty), difficulty),
+              duration_minutes = IF(VALUES(updated_at) >= updated_at, VALUES(duration_minutes), duration_minutes),
+              start_at = IF(VALUES(updated_at) >= updated_at, VALUES(start_at), start_at),
+              end_at = IF(VALUES(updated_at) >= updated_at, VALUES(end_at), end_at),
+              color = IF(VALUES(updated_at) >= updated_at, VALUES(color), color),
+              status = IF(VALUES(updated_at) >= updated_at, VALUES(status), status),
+              provider = IF(VALUES(updated_at) >= updated_at, VALUES(provider), provider),
+              account_id = IF(VALUES(updated_at) >= updated_at, VALUES(account_id), account_id),
+              google_id = IF(VALUES(updated_at) >= updated_at, VALUES(google_id), google_id),
+              outlook_id = IF(VALUES(updated_at) >= updated_at, VALUES(outlook_id), outlook_id),
+              ics_uid = IF(VALUES(updated_at) >= updated_at, VALUES(ics_uid), ics_uid),
+              updated_at = IF(VALUES(updated_at) >= updated_at, VALUES(updated_at), updated_at)`,
+            [
+              id,
+              title,
+              notes,
+              date,
+              eventType,
+              difficulty,
+              duration,
+              start,
+              end,
+              color,
+              status,
+              provider,
+              accountId,
+              googleId,
+              outlookId,
+              icsUid,
+              createdAt,
+              updatedAt,
+            ]
+          );
+        }
+
+        await conn.commit();
+      } catch (error) {
+        await conn.rollback();
+        throw error;
+      }
+    });
+  },
+};

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -6,6 +6,7 @@ import TasksScreen from "./screens/TasksScreen";
 import ConfigScreen from "./screens/ConfigScreen";
 import { initializeCalendarAccounts } from "./services/calendarAccountsStore";
 import { initializeCalendarSyncEngine } from "./services/calendarSyncManager";
+import { initializeEventSync } from "./services/eventSync";
 
 type Tela = "chat" | "agenda" | "tarefas" | "config";
 
@@ -47,6 +48,7 @@ export default function App() {
   const [tela, setTela] = useState<Tela>("chat");
 
   useEffect(() => {
+    initializeEventSync();
     (async () => {
       try {
         const storedAccounts = await initializeCalendarAccounts();

--- a/front/src/services/eventSync.ts
+++ b/front/src/services/eventSync.ts
@@ -1,0 +1,317 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import {
+  atualizarEvento,
+  encontrarEventoPorSyncId,
+  listarEventosAtualizadosDesde,
+  salvarEvento,
+  subscribeEventoChanges,
+  Evento,
+} from "../database";
+import { buildApiUrl } from "../config/api";
+
+const STORAGE_KEY = "@coach/eventSync";
+const SYNC_INTERVAL = 5 * 60 * 1000;
+const IMMEDIATE_SYNC_DELAY = 2_000;
+const INITIAL_SYNC_DELAY = 1_000;
+
+let initialized = false;
+let stateLoaded = false;
+let syncing = false;
+let pending = false;
+let suppressNotifications = false;
+
+let lastSyncAt: string | null = null;
+let intervalTimer: ReturnType<typeof setInterval> | null = null;
+let immediateTimer: ReturnType<typeof setTimeout> | null = null;
+let unsubscribeChanges: (() => void) | null = null;
+
+const sanitizeIso = (value?: string | null): string | null => {
+  if (!value || typeof value !== "string") {
+    return null;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  return date.toISOString();
+};
+
+const sanitizeOptionalString = (value?: string | null): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+type SyncEventPayload = {
+  id: string;
+  title: string;
+  notes: string | null;
+  date: string | null;
+  type: string;
+  difficulty: string;
+  duration: number;
+  start: string | null;
+  end: string | null;
+  color: string | null;
+  status: string | null;
+  provider: string | null;
+  accountId: string | null;
+  googleId: string | null;
+  outlookId: string | null;
+  icsUid: string | null;
+  updatedAt: string;
+  createdAt: string | null;
+};
+
+type SyncResponse = {
+  events?: SyncEventPayload[];
+  serverTime?: string;
+};
+
+const loadState = async () => {
+  if (stateLoaded) {
+    return;
+  }
+  try {
+    const raw = await AsyncStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw) as { lastSyncAt?: string | null };
+      if (typeof parsed?.lastSyncAt === "string" && parsed.lastSyncAt.trim()) {
+        const iso = sanitizeIso(parsed.lastSyncAt);
+        lastSyncAt = iso ?? lastSyncAt;
+      }
+    }
+  } catch (error) {
+    console.warn("[eventSync] failed to load state", error);
+  }
+  stateLoaded = true;
+};
+
+const persistState = async () => {
+  try {
+    await AsyncStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ lastSyncAt })
+    );
+  } catch (error) {
+    console.warn("[eventSync] failed to persist state", error);
+  }
+};
+
+const scheduleImmediateSync = (delay = IMMEDIATE_SYNC_DELAY) => {
+  if (!initialized) {
+    return;
+  }
+  if (immediateTimer) {
+    clearTimeout(immediateTimer);
+  }
+  immediateTimer = setTimeout(() => {
+    triggerEventSync().catch((error) => {
+      console.warn("[eventSync] immediate sync failed", error);
+    });
+  }, delay);
+};
+
+const startInterval = () => {
+  if (intervalTimer) {
+    clearInterval(intervalTimer);
+  }
+  intervalTimer = setInterval(() => {
+    triggerEventSync().catch((error) => {
+      console.warn("[eventSync] scheduled sync failed", error);
+    });
+  }, SYNC_INTERVAL);
+};
+
+const mapLocalToPayload = (evento: Evento): SyncEventPayload | null => {
+  if (!evento.syncId || !evento.syncId.trim()) {
+    return null;
+  }
+  const updatedAt = sanitizeIso(evento.updatedAt) ?? new Date().toISOString();
+  const createdAt = sanitizeIso(evento.createdAt) ?? updatedAt;
+  const duration =
+    typeof evento.tempoExecucao === "number" && Number.isFinite(evento.tempoExecucao)
+      ? Math.max(1, Math.round(evento.tempoExecucao))
+      : 15;
+  const provider = sanitizeOptionalString(evento.provider as string) ?? "local";
+  const accountId = sanitizeOptionalString(evento.accountId ?? undefined);
+
+  return {
+    id: evento.syncId,
+    title: evento.titulo,
+    notes: sanitizeOptionalString(evento.observacao),
+    date: sanitizeIso(evento.data) ?? sanitizeOptionalString(evento.data),
+    type: evento.tipo,
+    difficulty: evento.dificuldade,
+    duration,
+    start: sanitizeIso(evento.inicio) ?? sanitizeOptionalString(evento.inicio),
+    end: sanitizeIso(evento.fim) ?? sanitizeOptionalString(evento.fim),
+    color: sanitizeOptionalString(evento.cor),
+    status: sanitizeOptionalString(evento.status) ?? "ativo",
+    provider,
+    accountId,
+    googleId: sanitizeOptionalString(evento.googleId),
+    outlookId: sanitizeOptionalString(evento.outlookId),
+    icsUid: sanitizeOptionalString(evento.icsUid),
+    updatedAt,
+    createdAt,
+  };
+};
+
+const mapRemoteToEvento = (payload: SyncEventPayload): Evento => {
+  const updatedAt = sanitizeIso(payload.updatedAt) ?? new Date().toISOString();
+  const createdAt =
+    sanitizeIso(payload.createdAt) ??
+    sanitizeIso(payload.updatedAt) ??
+    updatedAt;
+  const duration =
+    typeof payload.duration === "number" && Number.isFinite(payload.duration)
+      ? Math.max(1, Math.round(payload.duration))
+      : 15;
+  const title = sanitizeOptionalString(payload.title) ?? "Evento";
+  const type = sanitizeOptionalString(payload.type) ?? "Tarefa";
+  const difficulty = sanitizeOptionalString(payload.difficulty) ?? "Media";
+  const provider = sanitizeOptionalString(payload.provider) ?? "local";
+  const status = sanitizeOptionalString(payload.status);
+  const accountId = sanitizeOptionalString(payload.accountId);
+  return {
+    titulo: title,
+    observacao: payload.notes ?? undefined,
+    data: payload.date ?? undefined,
+    tipo: type,
+    dificuldade: difficulty,
+    tempoExecucao: duration,
+    inicio: payload.start ?? undefined,
+    fim: payload.end ?? undefined,
+    cor: payload.color ?? undefined,
+    status: status ?? undefined,
+    provider: (provider as Evento["provider"]) ?? "local",
+    accountId: accountId ?? null,
+    googleId: payload.googleId ?? undefined,
+    outlookId: payload.outlookId ?? undefined,
+    icsUid: payload.icsUid ?? undefined,
+    updatedAt,
+    createdAt,
+    syncId: payload.id,
+  };
+};
+
+const applyRemoteEvents = async (events: SyncEventPayload[]) => {
+  if (events.length === 0) {
+    return;
+  }
+  suppressNotifications = true;
+  try {
+    for (const event of events) {
+      if (!event.id || !event.updatedAt) {
+        continue;
+      }
+      const local = await encontrarEventoPorSyncId(event.id);
+      const incoming = mapRemoteToEvento(event);
+      if (local?.updatedAt && sanitizeIso(local.updatedAt) === incoming.updatedAt) {
+        continue;
+      }
+      if (local?.id) {
+        await atualizarEvento({ ...local, ...incoming, id: local.id });
+      } else {
+        await salvarEvento(incoming);
+      }
+    }
+  } finally {
+    suppressNotifications = false;
+  }
+};
+
+const performSync = async () => {
+  await loadState();
+  const since = lastSyncAt;
+  const locais = await listarEventosAtualizadosDesde(since);
+  const payload = locais
+    .map(mapLocalToPayload)
+    .filter((item): item is SyncEventPayload => item !== null);
+
+  const body = JSON.stringify({
+    since,
+    events: payload,
+  });
+
+  const response = await fetch(buildApiUrl("/sync/events"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body,
+  });
+
+  const data: SyncResponse = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    const message = (data as any)?.error || response.statusText || "Sync failed";
+    throw new Error(message);
+  }
+
+  const remoteEvents = Array.isArray(data.events) ? data.events : [];
+  await applyRemoteEvents(remoteEvents);
+
+  const serverTimeIso = sanitizeIso(data.serverTime) ?? new Date().toISOString();
+  lastSyncAt = serverTimeIso;
+  await persistState();
+};
+
+export const triggerEventSync = async () => {
+  if (syncing) {
+    pending = true;
+    return;
+  }
+  syncing = true;
+  pending = false;
+  try {
+    await performSync();
+  } catch (error) {
+    console.warn("[eventSync] sync failed", error);
+    throw error;
+  } finally {
+    syncing = false;
+    if (pending) {
+      pending = false;
+      scheduleImmediateSync(IMMEDIATE_SYNC_DELAY);
+    }
+  }
+};
+
+export const initializeEventSync = () => {
+  if (initialized) {
+    return;
+  }
+  initialized = true;
+  startInterval();
+  scheduleImmediateSync(INITIAL_SYNC_DELAY);
+  unsubscribeChanges = subscribeEventoChanges(() => {
+    if (suppressNotifications) {
+      return;
+    }
+    scheduleImmediateSync();
+  });
+};
+
+export const disposeEventSync = () => {
+  if (!initialized) {
+    return;
+  }
+  initialized = false;
+  if (intervalTimer) {
+    clearInterval(intervalTimer);
+    intervalTimer = null;
+  }
+  if (immediateTimer) {
+    clearTimeout(immediateTimer);
+    immediateTimer = null;
+  }
+  if (unsubscribeChanges) {
+    unsubscribeChanges();
+    unsubscribeChanges = null;
+  }
+};
+


### PR DESCRIPTION
## Summary
- extend the Expo SQLite layer with sync metadata, change notifications, and helper queries to support online/offline event synchronization
- add a React Native event synchronization service that exchanges local updates with the backend when connectivity is available and initialize it at app startup
- create MySQL persistence for shared events along with repository helpers and an API endpoint to push and pull changes between clients

## Testing
- npm run build (backend)
- npm run test (frontend) *(fails: Jest cannot parse Expo ESM modules in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dbd25908c0832fbaf35b22c12410e3