### PR TITLE
Increase Express JSON payload limit for sync events

### DIFF
--- a/back/src/index.ts
+++ b/back/src/index.ts
@@ -13,7 +13,7 @@ import { normalizeHexColor } from "./utils/colors";
 import { decodeIdTokenPayload } from "./utils/jwt";
 const app = express();
 app.use(cors());
-app.use(express.json());
+app.use(express.json({ limit: "5mb" }));
 app.get("/health", (_req, res) => {
   res.json({ status: "ok", timestamp: new Date().toISOString() });
 });


### PR DESCRIPTION
## Summary
- raise the Express JSON body parser limit to 5 MB to handle larger sync/event payloads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbdcc62a88832fbd9c96a8c2207af1