### PR TITLE
Fix ICS synchronization to avoid Expo SQLite access conflicts

### DIFF
--- a/front/src/services/providers/icsSync.ts
+++ b/front/src/services/providers/icsSync.ts
@@ -1,10 +1,6 @@
 import { buildApiUrl } from "../../config/api";
 import { CalendarAccount } from "../../types/calendar";
-import {
-  Evento,
-  removerEventosSincronizados,
-  upsertEventoPorIcsUid,
-} from "../../database";
+import { Evento, substituirEventosIcs } from "../../database";
 import { updateCalendarAccountStatus } from "../calendarAccountsStore";
 
 const DEFAULT_DIFFICULTY = "Media";
@@ -292,10 +288,7 @@ export const syncIcsAccount = async (account: CalendarAccount) => {
     }
   }
 
-  await removerEventosSincronizados("ics", { accountId: account.id });
-  for (const evento of eventos) {
-    await upsertEventoPorIcsUid(evento);
-  }
+  await substituirEventosIcs(account.id, eventos);
 
   await updateCalendarAccountStatus(account.id, {
     status: "idle",


### PR DESCRIPTION
## Summary
- add internal database helpers to control notifications and reuse ICS upsert logic
- replace ICS synchronization with a single transactional bulk operation
- ensure updates notify listeners once after committing the new snapshot

## Testing
- npm test -- --watch=false *(fails: Jest cannot parse ESM dependency expo-font)*

------
https://chatgpt.com/codex/tasks/task_e_68dbdf612298832fa28ad94d970d6c04