### PR TITLE
Add pagination endpoints and integration date tracking for app events

### DIFF
--- a/back/migrations/004_add_integration_date_to_app_events.sql
+++ b/back/migrations/004_add_integration_date_to_app_events.sql
@@ -1,0 +1,4 @@
+ALTER TABLE app_events
+  ADD COLUMN integration_date DATETIME NULL AFTER updated_at;
+
+CREATE INDEX idx_app_events_integration_date ON app_events (integration_date);


### PR DESCRIPTION
## Summary
- add a migration to store the integration timestamp for app events
- reset the integration date on updates and expose paginated integration listings
- add an endpoint to mark events as integrated after export

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dbe2e133fc832f8d8e13d283cb765d