### PR TITLE
Filter cancelled tasks by title

### DIFF
--- a/front/src/utils/eventFilters.ts
+++ b/front/src/utils/eventFilters.ts
@@ -17,6 +17,18 @@ const CANCELLED_STATUS_SET = new Set(
 const normalizeStatus = (status?: string | null) =>
   typeof status === "string" ? status.trim().toLowerCase() : "";
 
+const normalizeTitle = (title?: string | null) =>
+  typeof title === "string" ? title.trim().toLowerCase() : "";
+
+const hasCancellationKeywordInTitle = (title?: string | null) => {
+  const normalized = normalizeTitle(title);
+  if (!normalized) {
+    return false;
+  }
+
+  return normalized.includes("cancelado");
+};
+
 const isCancelledStatus = (status?: string | null) => {
   const normalized = normalizeStatus(status);
   if (!normalized) {
@@ -55,6 +67,10 @@ const getVisibilityThreshold = (daysBack: number) => {
 
 export const shouldDisplayEvent = (event: Evento, daysBack = 3) => {
   if (isCancelledStatus(event.status)) {
+    return false;
+  }
+
+  if (hasCancellationKeywordInTitle(event.titulo)) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- avoid showing events whose titles contain "cancelado"
- reuse the visibility filter across agenda and task lists to hide cancelled cards

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc380b98bc832f9d9d3974d7af6e2f