### PR TITLE
Handle ICS recurrence expansion

### DIFF
--- a/front/src/services/providers/__tests__/icsSync.test.ts
+++ b/front/src/services/providers/__tests__/icsSync.test.ts
@@ -1,0 +1,55 @@
+import { expandRecurringEvents, mapIcsToEvento, parseIcsEvents } from "../icsSync";
+import { CalendarAccount } from "../../../types/calendar";
+
+jest.mock("../../../database", () => ({
+  substituirEventosIcs: jest.fn(),
+}));
+
+jest.mock("../../calendarAccountsStore", () => ({
+  updateCalendarAccountStatus: jest.fn(),
+}));
+
+jest.mock("../../eventSync", () => ({
+  triggerEventSync: jest.fn(),
+}));
+
+describe("ics recurrence expansion", () => {
+  const account: CalendarAccount = {
+    id: "account-1",
+    provider: "ics",
+    email: "user@example.com",
+    displayName: "User",
+    color: "#ffffff",
+  };
+
+  it("expands recurring events applying overrides and cancellations", () => {
+    const ics = `BEGIN:VCALENDAR\nVERSION:2.0\nBEGIN:VEVENT\nUID:event-1\nDTSTART:20250101T120000Z\nDTEND:20250101T130000Z\nRRULE:FREQ=DAILY;COUNT=3\nEXDATE:20250102T120000Z\nRDATE:20250105T120000Z\nSUMMARY:Evento original\nDESCRIPTION:Descricao base\nEND:VEVENT\nBEGIN:VEVENT\nUID:event-1\nRECURRENCE-ID:20250101T120000Z\nSTATUS:CANCELLED\nEND:VEVENT\nBEGIN:VEVENT\nUID:event-1\nRECURRENCE-ID:20250103T120000Z\nDTSTART:20250103T150000Z\nDTEND:20250103T160000Z\nSUMMARY:Evento alterado\nDESCRIPTION:Descricao alterada\nEND:VEVENT\nEND:VCALENDAR`;
+
+    const parsed = parseIcsEvents(ics);
+    expect(parsed).toHaveLength(3);
+
+    const expanded = expandRecurringEvents(parsed);
+    expect(expanded).toHaveLength(2);
+
+    const eventos = expanded
+      .map((item) => mapIcsToEvento(item, account))
+      .filter((item): item is NonNullable<ReturnType<typeof mapIcsToEvento>> => Boolean(item));
+
+    expect(eventos).toHaveLength(2);
+
+    const starts = eventos.map((evento) => evento.inicio);
+    expect(starts).toContain("2025-01-03T15:00:00.000Z");
+    expect(starts).toContain("2025-01-05T12:00:00.000Z");
+
+    const overrideEvento = eventos.find((evento) => evento.inicio === "2025-01-03T15:00:00.000Z");
+    expect(overrideEvento?.titulo).toBe("Evento alterado");
+    expect(overrideEvento?.observacao).toBe("Descricao alterada");
+
+    const regularEvento = eventos.find((evento) => evento.inicio === "2025-01-05T12:00:00.000Z");
+    expect(regularEvento?.titulo).toBe("Evento original");
+    expect(regularEvento?.observacao).toBe("Descricao base");
+
+    const uniqueIds = new Set(eventos.map((evento) => evento.icsUid));
+    expect(uniqueIds.size).toBe(eventos.length);
+  });
+});

--- a/front/src/services/providers/icsSync.ts
+++ b/front/src/services/providers/icsSync.ts
@@ -41,6 +41,10 @@ type ParsedIcsEvent = {
   end?: string | null;
   lastModified?: string | null;
   status?: string | null;
+  rrule?: string | null;
+  rdate?: (string | null)[];
+  exdate?: (string | null)[];
+  recurrenceId?: string | null;
 };
 
 type IcsProperty = {
@@ -154,7 +158,7 @@ const parseDateValue = (value: string, params: Record<string, string>): string |
   return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
 };
 
-const parseIcsEvents = (content: string): ParsedIcsEvent[] => {
+export const parseIcsEvents = (content: string): ParsedIcsEvent[] => {
   const lines = unfoldIcsLines(content);
   const events: ParsedIcsEvent[] = [];
   let current: ParsedIcsEvent | null = null;
@@ -171,9 +175,7 @@ const parseIcsEvents = (content: string): ParsedIcsEvent[] => {
 
     if (line.toUpperCase() === "END:VEVENT") {
       if (current && current.uid) {
-        if ((current.status ?? "").toUpperCase() !== "CANCELLED") {
-          events.push(current);
-        }
+        events.push(current);
       }
       current = null;
       continue;
@@ -212,12 +214,391 @@ const parseIcsEvents = (content: string): ParsedIcsEvent[] => {
       case "STATUS":
         current.status = value.trim();
         break;
+      case "RRULE":
+        current.rrule = value.trim() || null;
+        break;
+      case "RDATE": {
+        const values = value.split(",").map((chunk) => parseDateValue(chunk, params));
+        current.rdate = [...(current.rdate ?? []), ...values];
+        break;
+      }
+      case "EXDATE": {
+        const values = value.split(",").map((chunk) => parseDateValue(chunk, params));
+        current.exdate = [...(current.exdate ?? []), ...values];
+        break;
+      }
+      case "RECURRENCE-ID":
+        current.recurrenceId = parseDateValue(value, params);
+        break;
       default:
         break;
     }
   }
 
-  return events;
+  return events.filter((event) => {
+    if (!event.uid) {
+      return false;
+    }
+    const status = (event.status ?? "").toUpperCase();
+    if (status !== "CANCELLED") {
+      return true;
+    }
+    return Boolean(event.recurrenceId);
+  });
+};
+
+type RecurrenceGroup = {
+  master?: ParsedIcsEvent;
+  overrides: Map<string, ParsedIcsEvent>;
+  cancellations: Set<string>;
+  additional: ParsedIcsEvent[];
+};
+
+const MAX_OCCURRENCES = 500;
+const MS_IN_DAY = 24 * 60 * 60 * 1000;
+
+type ParsedRecurrenceRule = {
+  freq: "DAILY" | "WEEKLY" | "MONTHLY" | "YEARLY";
+  interval: number;
+  count?: number;
+  until?: string | null;
+  byDay?: number[];
+  byMonthDay?: number[];
+};
+
+const WEEKDAY_MAP: Record<string, number> = {
+  SU: 0,
+  MO: 1,
+  TU: 2,
+  WE: 3,
+  TH: 4,
+  FR: 5,
+  SA: 6,
+};
+
+const parseRRuleString = (rule: string): ParsedRecurrenceRule | null => {
+  const normalized = rule.trim();
+  if (!normalized) {
+    return null;
+  }
+
+  const parts = normalized.split(";");
+  const options: Record<string, string> = {};
+
+  for (const part of parts) {
+    const [rawKey, rawValue] = part.split("=");
+    if (!rawKey || !rawValue) {
+      continue;
+    }
+    options[rawKey.trim().toUpperCase()] = rawValue.trim();
+  }
+
+  const freq = options.FREQ?.toUpperCase();
+  if (!freq || !["DAILY", "WEEKLY", "MONTHLY", "YEARLY"].includes(freq)) {
+    return null;
+  }
+
+  const interval = Math.max(1, Number.parseInt(options.INTERVAL ?? "1", 10) || 1);
+  const countValue = options.COUNT ? Number.parseInt(options.COUNT, 10) : undefined;
+  const count = countValue && countValue > 0 ? countValue : undefined;
+  const until = options.UNTIL ? parseDateValue(options.UNTIL, {}) : undefined;
+
+  let byDay: number[] | undefined;
+  if (options.BYDAY) {
+    byDay = options.BYDAY.split(",")
+      .map((chunk) => chunk.trim())
+      .map((chunk) => WEEKDAY_MAP[chunk.slice(-2).toUpperCase()] ?? null)
+      .filter((value): value is number => value !== null);
+    if (byDay.length === 0) {
+      byDay = undefined;
+    }
+  }
+
+  let byMonthDay: number[] | undefined;
+  if (options.BYMONTHDAY) {
+    byMonthDay = options.BYMONTHDAY.split(",")
+      .map((chunk) => Number.parseInt(chunk.trim(), 10))
+      .filter((value) => Number.isFinite(value));
+    if (byMonthDay.length === 0) {
+      byMonthDay = undefined;
+    }
+  }
+
+  return {
+    freq: freq as ParsedRecurrenceRule["freq"],
+    interval,
+    count,
+    until: until ?? null,
+    byDay,
+    byMonthDay,
+  };
+};
+
+const addDays = (date: Date, amount: number) => {
+  const next = new Date(date);
+  next.setUTCDate(next.getUTCDate() + amount);
+  return next;
+};
+
+const diffInDays = (start: Date, end: Date) => Math.floor((end.getTime() - start.getTime()) / MS_IN_DAY);
+
+const matchesRule = (candidate: Date, start: Date, rule: ParsedRecurrenceRule): boolean => {
+  const diffDays = diffInDays(start, candidate);
+  if (diffDays <= 0) {
+    return false;
+  }
+
+  switch (rule.freq) {
+    case "DAILY": {
+      if (diffDays % rule.interval !== 0) {
+        return false;
+      }
+      if (rule.byDay && !rule.byDay.includes(candidate.getUTCDay())) {
+        return false;
+      }
+      return true;
+    }
+    case "WEEKLY": {
+      const diffWeeks = Math.floor(diffDays / 7);
+      if (diffWeeks % rule.interval !== 0) {
+        return false;
+      }
+      const allowedDays = rule.byDay && rule.byDay.length > 0 ? rule.byDay : [start.getUTCDay()];
+      return allowedDays.includes(candidate.getUTCDay());
+    }
+    case "MONTHLY": {
+      const startMonthIndex = start.getUTCFullYear() * 12 + start.getUTCMonth();
+      const candidateMonthIndex = candidate.getUTCFullYear() * 12 + candidate.getUTCMonth();
+      const diffMonths = candidateMonthIndex - startMonthIndex;
+      if (diffMonths < 0 || diffMonths % rule.interval !== 0) {
+        return false;
+      }
+      const days = rule.byMonthDay && rule.byMonthDay.length > 0 ? rule.byMonthDay : [start.getUTCDate()];
+      return days.includes(candidate.getUTCDate());
+    }
+    case "YEARLY": {
+      const diffYears = candidate.getUTCFullYear() - start.getUTCFullYear();
+      if (diffYears <= 0 || diffYears % rule.interval !== 0) {
+        return false;
+      }
+      return (
+        candidate.getUTCMonth() === start.getUTCMonth() && candidate.getUTCDate() === start.getUTCDate()
+      );
+    }
+    default:
+      return false;
+  }
+};
+
+const generateOccurrencesFromRule = (
+  start: Date,
+  rule: ParsedRecurrenceRule,
+  occurrences: Set<string>,
+) => {
+  const targetCount = Math.min(MAX_OCCURRENCES, rule.count ?? MAX_OCCURRENCES);
+  const untilDate = rule.until ? new Date(rule.until) : null;
+  let candidate = new Date(start);
+  let safety = 0;
+
+  while (occurrences.size < targetCount) {
+    candidate = addDays(candidate, 1);
+    safety += 1;
+
+    if (safety > MAX_OCCURRENCES * 366) {
+      break;
+    }
+
+    if (untilDate && candidate > untilDate) {
+      break;
+    }
+
+    if (!matchesRule(candidate, start, rule)) {
+      continue;
+    }
+
+    const iso = candidate.toISOString();
+    if (!occurrences.has(iso)) {
+      occurrences.add(iso);
+    }
+  }
+};
+
+export const expandRecurringEvents = (events: ParsedIcsEvent[]): ParsedIcsEvent[] => {
+  const result: ParsedIcsEvent[] = [];
+  const groups = new Map<string, RecurrenceGroup>();
+
+  const getGroup = (uid: string): RecurrenceGroup => {
+    let group = groups.get(uid);
+    if (!group) {
+      group = { overrides: new Map(), cancellations: new Set(), additional: [] };
+      groups.set(uid, group);
+    }
+    return group;
+  };
+
+  for (const event of events) {
+    if (!event.uid) {
+      continue;
+    }
+
+    const hasRecurrenceData = Boolean(event.rrule || (event.rdate && event.rdate.length > 0) || event.recurrenceId);
+    if (!hasRecurrenceData) {
+      result.push(event);
+      continue;
+    }
+
+    const group = getGroup(event.uid);
+    if (event.recurrenceId) {
+      if ((event.status ?? "").toUpperCase() === "CANCELLED") {
+        group.cancellations.add(event.recurrenceId);
+      } else {
+        group.overrides.set(event.recurrenceId, event);
+      }
+      continue;
+    }
+
+    if (event.rrule || (event.rdate && event.rdate.length > 0)) {
+      if (!group.master) {
+        group.master = event;
+      } else {
+        group.additional.push(event);
+      }
+      continue;
+    }
+
+    group.additional.push(event);
+  }
+
+  if (groups.size === 0) {
+    return result;
+  }
+
+  groups.forEach((group) => {
+    const { master, overrides, cancellations, additional } = group;
+    if (!master) {
+      result.push(...additional);
+      overrides.forEach((override) => result.push(override));
+      return;
+    }
+
+    const masterStart = master.start ? new Date(master.start) : null;
+    const masterEnd = master.end ? new Date(master.end) : null;
+    const baseDuration = masterStart && masterEnd ? Math.max(0, masterEnd.getTime() - masterStart.getTime()) : 0;
+
+    if (!masterStart || Number.isNaN(masterStart.getTime())) {
+      if ((master.status ?? "").toUpperCase() !== "CANCELLED") {
+        result.push(master);
+      }
+      overrides.forEach((override) => {
+        if ((override.status ?? "").toUpperCase() !== "CANCELLED") {
+          result.push(override);
+        }
+      });
+      result.push(...additional);
+      return;
+    }
+
+    const occurrenceSet = new Set<string>();
+    const addOccurrence = (date: Date | null | undefined) => {
+      if (!date || Number.isNaN(date.getTime())) {
+        return;
+      }
+      if (occurrenceSet.size >= MAX_OCCURRENCES) {
+        return;
+      }
+      occurrenceSet.add(date.toISOString());
+    };
+
+    addOccurrence(masterStart);
+
+    if (master.rrule) {
+      const parsedRule = parseRRuleString(master.rrule);
+      if (parsedRule) {
+        generateOccurrencesFromRule(masterStart, parsedRule, occurrenceSet);
+      } else {
+        console.warn("[ics] invalid RRULE ignored", master.rrule);
+      }
+    }
+
+    for (const rdate of master.rdate ?? []) {
+      if (!rdate) {
+        continue;
+      }
+      const date = new Date(rdate);
+      addOccurrence(date);
+    }
+
+    overrides.forEach((_, recurrenceKey) => {
+      if (occurrenceSet.size >= MAX_OCCURRENCES) {
+        return;
+      }
+      if (!occurrenceSet.has(recurrenceKey)) {
+        occurrenceSet.add(recurrenceKey);
+      }
+    });
+
+    for (const exdate of master.exdate ?? []) {
+      if (!exdate) {
+        continue;
+      }
+      const date = new Date(exdate);
+      if (!Number.isNaN(date.getTime())) {
+        occurrenceSet.delete(date.toISOString());
+      }
+    }
+
+    cancellations.forEach((recurrenceId) => {
+      occurrenceSet.delete(recurrenceId);
+    });
+
+    const occurrences = Array.from(occurrenceSet).sort();
+
+    for (const occurrenceIso of occurrences) {
+      if (cancellations.has(occurrenceIso)) {
+        continue;
+      }
+
+      const override = overrides.get(occurrenceIso);
+      const startIso = override?.start ?? occurrenceIso;
+      let endIso = override?.end ?? null;
+
+      if (!endIso && baseDuration > 0) {
+        const endDate = new Date(new Date(startIso).getTime() + baseDuration);
+        endIso = endDate.toISOString();
+      } else if (!endIso) {
+        endIso = startIso;
+      }
+
+      const merged: ParsedIcsEvent = {
+        ...master,
+        start: startIso,
+        end: endIso,
+        rrule: null,
+        rdate: undefined,
+        exdate: undefined,
+        recurrenceId: undefined,
+        lastModified: override?.lastModified ?? master.lastModified ?? null,
+      };
+
+      if (override) {
+        if (override.summary !== undefined) {
+          merged.summary = override.summary;
+        }
+        if (override.description !== undefined) {
+          merged.description = override.description;
+        }
+        if (override.status !== undefined) {
+          merged.status = override.status;
+        }
+      }
+
+      result.push(merged);
+    }
+
+    result.push(...additional);
+  });
+
+  return result;
 };
 
 const diferencaEmMinutos = (inicio?: string | null, fim?: string | null) => {
@@ -233,7 +614,7 @@ const diferencaEmMinutos = (inicio?: string | null, fim?: string | null) => {
   return Math.round(diff / 60000);
 };
 
-const mapIcsToEvento = (item: ParsedIcsEvent, account: CalendarAccount): Evento | null => {
+export const mapIcsToEvento = (item: ParsedIcsEvent, account: CalendarAccount): Evento | null => {
   const inicioIso = item.start;
   if (!inicioIso) {
     return null;
@@ -252,7 +633,7 @@ const mapIcsToEvento = (item: ParsedIcsEvent, account: CalendarAccount): Evento 
     inicio: inicioIso,
     fim: fimIso,
     cor: account.color,
-    icsUid: item.uid,
+    icsUid: item.uid && item.start ? `${item.uid}::${item.start}` : item.uid,
     updatedAt: item.lastModified ?? new Date().toISOString(),
     provider: "ics",
     accountId: account.id,
@@ -280,7 +661,7 @@ export const syncIcsAccount = async (account: CalendarAccount) => {
     throw new Error("O arquivo ICS está vazio.");
   }
 
-  const parsedEvents = parseIcsEvents(content);
+  const parsedEvents = expandRecurringEvents(parseIcsEvents(content));
   const eventos: Evento[] = [];
   for (const item of parsedEvents) {
     const evento = mapIcsToEvento(item, account);


### PR DESCRIPTION
## Summary
- parse recurrence metadata from ICS events and expand them into concrete occurrences while applying overrides and cancellations
- ensure mapped ICS events generate unique identifiers per occurrence before syncing
- add Jest coverage for recurring VEVENT scenarios, overrides, and cancellations

## Testing
- npm test -- icsSync.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68dc4338b5b0832f90a45543b35cdd87