### PR TITLE
Add recurring badge to tasks and adjust agenda short card layout

### DIFF
--- a/front/src/screens/AgendaScreen.tsx
+++ b/front/src/screens/AgendaScreen.tsx
@@ -378,6 +378,8 @@ export default function AgendaScreen() {
                   DURACAO_MINIMA * MINUTE_HEIGHT
                 );
                 const isEventoCurto = altura <= DURACAO_MINIMA * MINUTE_HEIGHT + 2;
+                const isShortDuration = (ev.tempoExecucao ?? DURACAO_MINIMA) <= DURACAO_MINIMA;
+                const titleNumberOfLines = isShortDuration || isEventoCurto ? 2 : undefined;
 
                 const estiloDinamico: any = {
                   top: ev.startMin * MINUTE_HEIGHT,
@@ -406,22 +408,28 @@ export default function AgendaScreen() {
                     activeOpacity={0.85}
                   >
                     <Text
-                      style={[styles.eventoTexto, isEventoCurto && styles.eventoTextoCurto]}
-                      numberOfLines={isEventoCurto ? 2 : undefined}
+                      style={[
+                        styles.eventoTexto,
+                        isEventoCurto && styles.eventoTextoCurto,
+                        isShortDuration && styles.eventoTextoShortDuration,
+                      ]}
+                      numberOfLines={titleNumberOfLines}
                     >
                       {ev.titulo}
                     </Text>
-                    <Text style={[styles.eventoHora, isEventoCurto && styles.eventoHoraCurta]}>
-                      {new Date(ev.inicio ?? "").toLocaleTimeString("pt-BR", {
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })}
-                      {" "}-{" "}
-                      {new Date(ev.fim ?? "").toLocaleTimeString("pt-BR", {
-                        hour: "2-digit",
-                        minute: "2-digit",
-                      })}
-                    </Text>
+                    {!isShortDuration && (
+                      <Text style={[styles.eventoHora, isEventoCurto && styles.eventoHoraCurta]}>
+                        {new Date(ev.inicio ?? "").toLocaleTimeString("pt-BR", {
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                        {" "}-{" "}
+                        {new Date(ev.fim ?? "").toLocaleTimeString("pt-BR", {
+                          hour: "2-digit",
+                          minute: "2-digit",
+                        })}
+                      </Text>
+                    )}
 
                     {ev.overlaps.map((intervalo, idx) => {
                       const sobreposicaoInicio = intervalo.start - ev.startMin;
@@ -776,6 +784,10 @@ const styles = StyleSheet.create({
   eventoTextoCurto: {
     fontSize: 12,
     lineHeight: 16,
+  },
+  eventoTextoShortDuration: {
+    textAlign: "center",
+    width: "100%",
   },
   eventoHora: { color: "#fff", fontSize: 12, marginTop: 4, lineHeight: 16 },
   eventoHoraCurta: {

--- a/front/src/screens/TasksScreen.tsx
+++ b/front/src/screens/TasksScreen.tsx
@@ -65,6 +65,27 @@ const calculateOpenDays = (task: Task) => {
   const days = Math.floor(diffMs / (1000 * 60 * 60 * 24));
   return days >= 0 ? days : 0;
 };
+const isRecurringTask = (task: Task) => {
+  const normalizedType = (task.tipo ?? "").toLowerCase();
+  if (normalizedType.includes("recorr")) {
+    return true;
+  }
+
+  if (typeof task.icsUid === "string" && task.icsUid.includes("::")) {
+    return true;
+  }
+
+  if (typeof task.googleId === "string" && task.googleId.includes("_")) {
+    return true;
+  }
+
+  if (typeof task.outlookId === "string" && task.outlookId.includes("_")) {
+    return true;
+  }
+
+  return false;
+};
+
 type TaskCardProps = {
   task: Task;
   onEdit: () => void;
@@ -81,6 +102,7 @@ const TaskCard = ({ task, onEdit }: TaskCardProps) => {
   const calendarColor = normalizeCalendarColor(task.cor ?? DEFAULT_CALENDAR_CATEGORY.color);
   const categoryLabel = getCalendarCategoryLabel(task.cor ?? null);
   const badgeBackground = `${calendarColor}26`;
+  const recurring = isRecurringTask(task);
   return (
     <TouchableOpacity
       style={styles.cardWrapper}
@@ -94,6 +116,11 @@ const TaskCard = ({ task, onEdit }: TaskCardProps) => {
             {task.titulo}
           </Text>
           <View style={styles.cardHeaderRight}>
+            {recurring && (
+              <View style={styles.recurringTag}>
+                <Text style={styles.recurringTagText}>Recorrente</Text>
+              </View>
+            )}
             <View style={[styles.cardCategoryBadge, { backgroundColor: badgeBackground }]}>
               <View style={[styles.cardCategoryDot, { backgroundColor: calendarColor }]} />
               <Text style={styles.cardCategoryText}>{categoryLabel}</Text>
@@ -448,6 +475,17 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
+  },
+  recurringTag: {
+    backgroundColor: "#264653",
+    paddingHorizontal: 8,
+    paddingVertical: 2,
+    borderRadius: 999,
+  },
+  recurringTagText: {
+    color: "#fff",
+    fontSize: 12,
+    fontWeight: "600",
   },
   cardCategoryBadge: {
     flexDirection: "row",


### PR DESCRIPTION
## Summary
- add recurring detection and badge to the task list cards
- hide time range for 15-minute agenda cards and center the title for short items

## Testing
- npm run web *(fails: Expo CLI cannot fetch native module versions in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc48c02068832fb179fe9ce1baaced