### PR TITLE
Fix card title alignment on agenda and tasks screens

### DIFF
--- a/front/src/screens/AgendaScreen.tsx
+++ b/front/src/screens/AgendaScreen.tsx
@@ -398,6 +398,7 @@ export default function AgendaScreen() {
                 if (isEventoCurto) {
                   estiloDinamico.paddingVertical = 4;
                   estiloDinamico.justifyContent = "center";
+                  estiloDinamico.alignItems = "flex-start";
                 }
 
                 return (
@@ -780,13 +781,14 @@ const styles = StyleSheet.create({
     fontWeight: "bold",
     fontSize: 14,
     lineHeight: 18,
+    textAlign: "left",
   },
   eventoTextoCurto: {
     fontSize: 12,
     lineHeight: 16,
   },
   eventoTextoShortDuration: {
-    textAlign: "center",
+    textAlign: "left",
     width: "100%",
   },
   eventoHora: { color: "#fff", fontSize: 12, marginTop: 4, lineHeight: 16 },

--- a/front/src/screens/TasksScreen.tsx
+++ b/front/src/screens/TasksScreen.tsx
@@ -112,9 +112,6 @@ const TaskCard = ({ task, onEdit }: TaskCardProps) => {
       <View style={[styles.cardAccent, { backgroundColor: calendarColor }]} />
       <View style={styles.cardContent}>
         <View style={styles.cardHeader}>
-          <Text style={styles.cardTitle} numberOfLines={2}>
-            {task.titulo}
-          </Text>
           <View style={styles.cardHeaderRight}>
             {recurring && (
               <View style={styles.recurringTag}>
@@ -127,6 +124,9 @@ const TaskCard = ({ task, onEdit }: TaskCardProps) => {
             </View>
             <Ionicons name="create-outline" size={20} style={styles.cardHeaderIcon} />
           </View>
+          <Text style={styles.cardTitle} numberOfLines={2}>
+            {task.titulo}
+          </Text>
         </View>
         <View style={styles.cardMetaRow}>
           <Ionicons name="time-outline" size={16} style={styles.metaIcon} />
@@ -466,8 +466,7 @@ const styles = StyleSheet.create({
     padding: 16,
   },
   cardHeader: {
-    flexDirection: "row",
-    justifyContent: "space-between",
+    flexDirection: "column",
     alignItems: "flex-start",
     gap: 12,
   },
@@ -475,6 +474,7 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "center",
     gap: 8,
+    alignSelf: "flex-end",
   },
   recurringTag: {
     backgroundColor: "#264653",
@@ -506,11 +506,10 @@ const styles = StyleSheet.create({
     color: "#0f172a",
   },
   cardTitle: {
-    flex: 1,
     fontSize: 17,
     fontWeight: "700",
     color: "#1f2d3d",
-    marginRight: 12,
+    alignSelf: "stretch",
   },
   cardHeaderIcon: {
     color: "#1c6b73",


### PR DESCRIPTION
## Summary
- ensure agenda card titles stay left-aligned, including short-duration events
- stack task card titles under their tag row while keeping badges aligned to the right

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc4af761e4832f992799ae5024cee2