### PR TITLE
Fix integration date reset during sync upserts

### DIFF
--- a/back/src/repositories/appEventRepository.ts
+++ b/back/src/repositories/appEventRepository.ts
@@ -169,7 +169,11 @@ export const appEventRepository = {
               updated_at = IF(VALUES(updated_at) > updated_at, VALUES(updated_at), updated_at),
               integration_date = IF(
                 VALUES(updated_at) > updated_at,
-                VALUES(integration_date),
+                IF(
+                  VALUES(integration_date) IS NULL,
+                  integration_date,
+                  VALUES(integration_date)
+                ),
                 integration_date
               )`,
             [


### PR DESCRIPTION
## Summary
- prevent upserts from overwriting integration_date when the payload omits it

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd6f3b9c7c832f9aa657d9df9cd23a