### PR TITLE
Reduce redundant sync polling and persist integration metadata

### DIFF
--- a/front/src/database.ts
+++ b/front/src/database.ts
@@ -22,9 +22,25 @@ export type Evento = {
   provider?: CalendarProvider | "local";
   accountId?: string | null;
   status?: "ativo" | "removido" | string;
+  integrationDate?: string | null;
 };
 
 const DEFAULT_TEMPO_EXECUCAO = 15;
+
+const sanitizeIsoString = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  return parsed.toISOString();
+};
 
 const sanitizeTempoExecucao = (
   value: unknown,
@@ -140,6 +156,7 @@ const dbPromise = (async () => {
   await adicionarColuna(database, "provider", "TEXT DEFAULT 'local'");
   await adicionarColuna(database, "accountId", "TEXT");
   await adicionarColuna(database, "status", "TEXT DEFAULT 'ativo'");
+  await adicionarColuna(database, "integrationDate", "TEXT");
 
   await database.execAsync(
     "CREATE INDEX IF NOT EXISTS idx_eventos_provider ON eventos(provider)"
@@ -220,6 +237,7 @@ const mapRowToEvento = (row: any): Evento => ({
   provider: (row.provider as CalendarProvider | "local") ?? "local",
   accountId: row.accountId ?? null,
   status: row.status ?? undefined,
+  integrationDate: row.integrationDate ?? undefined,
 });
 
 const normalizarEvento = (ev: Evento): Evento => {
@@ -230,6 +248,7 @@ const normalizarEvento = (ev: Evento): Evento => {
   const status = ev.status ?? "ativo";
   const cor = normalizeCalendarColor(ev.cor);
   const tempoExecucao = sanitizeTempoExecucao(ev.tempoExecucao);
+  const integrationDate = sanitizeIsoString(ev.integrationDate ?? null);
   return {
     ...ev,
     provider,
@@ -237,6 +256,7 @@ const normalizarEvento = (ev: Evento): Evento => {
     status,
     cor,
     tempoExecucao,
+    integrationDate,
   };
 };
 
@@ -256,6 +276,7 @@ const salvarEventoInternal = async (
   const updatedAt = evento.updatedAt ?? new Date().toISOString();
   const createdAt = evento.createdAt ?? updatedAt;
   const syncId = evento.syncId && evento.syncId.trim() ? evento.syncId : generateSyncId();
+  const integrationDate = evento.integrationDate ?? null;
 
   const resultado = await db.runAsync(
     `INSERT INTO eventos (
@@ -276,8 +297,9 @@ const salvarEventoInternal = async (
       syncId,
       provider,
       accountId,
-      status
-    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      status,
+      integrationDate
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     [
       evento.titulo,
       evento.observacao ?? "",
@@ -297,6 +319,7 @@ const salvarEventoInternal = async (
       evento.provider,
       evento.accountId ?? null,
       evento.status ?? "ativo",
+      integrationDate,
     ]
   );
 
@@ -321,12 +344,13 @@ const atualizarEventoInternal = async (
   const inicioBase = evento.inicio ?? evento.data ?? new Date().toISOString();
   const fimCalculado = evento.fim ?? calcularFim(inicioBase, tempo);
   const updatedAt = evento.updatedAt ?? new Date().toISOString();
+  const integrationDate = evento.integrationDate ?? null;
 
   await db.runAsync(
     `UPDATE eventos
      SET titulo = ?, observacao = ?, data = ?, tipo = ?, dificuldade = ?, tempoExecucao = ?, inicio = ?, fim = ?,
         cor = ?, googleId = ?, outlookId = ?, icsUid = ?, updatedAt = ?, provider = ?, accountId = ?, status = ?,
-        syncId = COALESCE(?, syncId)
+        integrationDate = ?, syncId = COALESCE(?, syncId)
      WHERE id = ?`,
     [
       evento.titulo,
@@ -345,6 +369,7 @@ const atualizarEventoInternal = async (
       evento.provider,
       evento.accountId ?? null,
       evento.status ?? "ativo",
+      integrationDate,
       evento.syncId ?? null,
       evento.id,
     ]

--- a/front/src/screens/AgendaScreen.tsx
+++ b/front/src/screens/AgendaScreen.tsx
@@ -672,7 +672,7 @@ export default function AgendaScreen() {
           }
           await carregarEventos();
           try {
-            await triggerEventSync();
+            await triggerEventSync({ force: true });
           } catch (error) {
             console.warn("[agenda] failed to trigger sync after save", error);
           }

--- a/front/src/screens/ConfigScreen.tsx
+++ b/front/src/screens/ConfigScreen.tsx
@@ -783,7 +783,7 @@ export default function ConfigScreen() {
       });
       await removeCalendarAccount(disconnectingAccount.id);
       try {
-        await triggerEventSync();
+        await triggerEventSync({ force: true });
       } catch (error) {
         console.warn("[config] failed to trigger sync after disconnect", error);
       }

--- a/front/src/screens/TasksScreen.tsx
+++ b/front/src/screens/TasksScreen.tsx
@@ -294,7 +294,7 @@ export default function TasksScreen() {
     }
     await carregarTarefas();
     try {
-      await triggerEventSync();
+      await triggerEventSync({ force: true });
     } catch (error) {
       console.warn("[tasks] failed to trigger sync after save", error);
     }
@@ -323,7 +323,7 @@ export default function TasksScreen() {
       }
     }
     try {
-      await triggerEventSync();
+      await triggerEventSync({ force: true });
     } catch (error) {
       console.warn("[tasks] failed to trigger sync after delete", error);
     }

--- a/front/src/services/providers/googleSync.ts
+++ b/front/src/services/providers/googleSync.ts
@@ -309,7 +309,7 @@ export const syncGoogleAccount = async (account: CalendarAccount) => {
   }
 
   try {
-    await triggerEventSync();
+    await triggerEventSync({ force: true });
   } catch (error) {
     console.warn("[google] failed to trigger sync after provider import", error);
   }

--- a/front/src/services/providers/icsSync.ts
+++ b/front/src/services/providers/icsSync.ts
@@ -673,7 +673,7 @@ export const syncIcsAccount = async (account: CalendarAccount) => {
   await substituirEventosIcs(account.id, eventos);
 
   try {
-    await triggerEventSync();
+    await triggerEventSync({ force: true });
   } catch (error) {
     console.warn("[ics] failed to trigger sync after provider import", error);
   }

--- a/front/src/services/providers/outlookSync.ts
+++ b/front/src/services/providers/outlookSync.ts
@@ -306,7 +306,7 @@ export const syncOutlookAccount = async (account: CalendarAccount) => {
   }
 
   try {
-    await triggerEventSync();
+    await triggerEventSync({ force: true });
   } catch (error) {
     console.warn("[outlook] failed to trigger sync after provider import", error);
   }


### PR DESCRIPTION
## Summary
- throttle event sync requests when no local updates are pending while preserving forced remote pulls
- persist the integrationDate field locally and include it in sync payloads
- update manual sync entry points to trigger forced remote syncs when requested

## Testing
- npm test -- --watch=false

------
https://chatgpt.com/codex/tasks/task_e_68dd8d3c1590832f84be84b3c47666f0