### PR TITLE
Adjust layout spacing on configuration and tasks screens

### DIFF
--- a/front/src/screens/ConfigScreen.tsx
+++ b/front/src/screens/ConfigScreen.tsx
@@ -874,7 +874,11 @@ export default function ConfigScreen() {
   );
 
   return (
-    <ScrollView contentContainerStyle={styles.container}>
+    <ScrollView
+      style={styles.scroll}
+      contentContainerStyle={styles.container}
+      showsVerticalScrollIndicator={false}
+    >
       <TouchableOpacity
         style={styles.importButton}
         onPress={openProviderModal}
@@ -1136,8 +1140,14 @@ export default function ConfigScreen() {
 }
 
 const styles = StyleSheet.create({
+  scroll: {
+    flex: 1,
+    backgroundColor: "#f4f7fb",
+  },
   container: {
-    padding: 24,
+    paddingHorizontal: 20,
+    paddingTop: 24,
+    paddingBottom: 0,
     gap: 16,
   },
   loadingContainer: {

--- a/front/src/screens/ConfigScreen.tsx
+++ b/front/src/screens/ConfigScreen.tsx
@@ -1147,10 +1147,11 @@ const styles = StyleSheet.create({
   screen: {
     flex: 1,
     backgroundColor: "#f4f7fb",
-  },
-  contentContainer: {
     paddingHorizontal: 20,
     paddingTop: 24,
+    paddingBottom: 0,
+  },
+  contentContainer: {
     paddingBottom: 0,
   },
   loadingContainer: {

--- a/front/src/screens/ConfigScreen.tsx
+++ b/front/src/screens/ConfigScreen.tsx
@@ -874,11 +874,7 @@ export default function ConfigScreen() {
   );
 
   return (
-    <ScrollView
-      style={styles.scroll}
-      contentContainerStyle={styles.container}
-      showsVerticalScrollIndicator={false}
-    >
+    <ScrollView style={styles.scroll} showsVerticalScrollIndicator={false}>
       <TouchableOpacity
         style={styles.importButton}
         onPress={openProviderModal}
@@ -1143,15 +1139,13 @@ const styles = StyleSheet.create({
   scroll: {
     flex: 1,
     backgroundColor: "#f4f7fb",
-  },
-  container: {
     paddingHorizontal: 20,
     paddingTop: 24,
     paddingBottom: 0,
-    gap: 16,
   },
   loadingContainer: {
     paddingVertical: 32,
+    marginTop: 16,
     alignItems: "center",
   },
   importButton: {
@@ -1167,6 +1161,7 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 2 },
     shadowOpacity: 0.05,
     shadowRadius: 6,
+    marginBottom: 16,
   },
   importButtonText: {
     fontSize: 18,
@@ -1180,10 +1175,12 @@ const styles = StyleSheet.create({
   feedbackText: {
     color: "#2a9d8f",
     fontSize: 14,
+    marginBottom: 12,
   },
   errorText: {
     color: "#e53935",
     fontSize: 14,
+    marginBottom: 12,
   },
   accountCard: {
     backgroundColor: "#ffffff",
@@ -1195,6 +1192,7 @@ const styles = StyleSheet.create({
     shadowOffset: { width: 0, height: 4 },
     shadowOpacity: 0.05,
     shadowRadius: 8,
+    marginBottom: 16,
   },
   accountHeader: {
     flexDirection: "row",

--- a/front/src/screens/ConfigScreen.tsx
+++ b/front/src/screens/ConfigScreen.tsx
@@ -874,66 +874,73 @@ export default function ConfigScreen() {
   );
 
   return (
-    <ScrollView style={styles.scroll} showsVerticalScrollIndicator={false}>
-      <TouchableOpacity
-        style={styles.importButton}
-        onPress={openProviderModal}
-        disabled={connectingProvider !== null}
+    <View style={styles.screen}>
+      <ScrollView
+        contentContainerStyle={styles.contentContainer}
+        showsVerticalScrollIndicator={false}
       >
-        <Text style={styles.importButtonText}>Importar Calendário</Text>
-        <View style={styles.importIconsRow}>
-          {providerOptions.map((option) => (
-            <MaterialCommunityIcons
-              key={option.id}
-              name={option.icon}
-              size={28}
-              color="#1f2d3d"
-              style={{ opacity: connectingProvider ? 0.4 : 1 }}
-            />
-          ))}
-        </View>
-      </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.importButton}
+          onPress={openProviderModal}
+          disabled={connectingProvider !== null}
+        >
+          <Text style={styles.importButtonText}>Importar Calendário</Text>
+          <View style={styles.importIconsRow}>
+            {providerOptions.map((option) => (
+              <MaterialCommunityIcons
+                key={option.id}
+                name={option.icon}
+                size={28}
+                color="#1f2d3d"
+                style={{ opacity: connectingProvider ? 0.4 : 1 }}
+              />
+            ))}
+          </View>
+        </TouchableOpacity>
 
-      {feedbackMessage ? <Text style={styles.feedbackText}>{feedbackMessage}</Text> : null}
-      {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
+        {feedbackMessage ? <Text style={styles.feedbackText}>{feedbackMessage}</Text> : null}
+        {errorMessage ? <Text style={styles.errorText}>{errorMessage}</Text> : null}
 
-      {loading ? (
-        <View style={styles.loadingContainer}>
-          <ActivityIndicator size="large" color="#2a9d8f" />
-        </View>
-      ) : (
-        sortedAccounts.map(renderAccountCard)
-      )}
+        {loading ? (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator size="large" color="#2a9d8f" />
+          </View>
+        ) : (
+          sortedAccounts.map(renderAccountCard)
+        )}
 
-      <Modal
-        visible={importModalVisible}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setImportModalVisible(false)}
-      >
-        <View style={styles.modalOverlay}>
-          <View style={styles.providerModalContent}>
-            <Text style={styles.modalTitle}>Escolha o calendário</Text>
-            <Text style={styles.modalMessage}>Selecione o provedor que deseja importar.</Text>
-            <View style={styles.providerList}>
-              {providerOptions.map((option) => (
-                <TouchableOpacity
-                  key={option.id}
-                  style={styles.providerOption}
-                  onPress={() => handleSelectProvider(option)}
-                >
-                  <MaterialCommunityIcons name={option.icon} size={28} color="#264653" />
-                  <View style={styles.providerTexts}>
-                    <Text style={styles.providerTitle}>{option.title}</Text>
-                    <Text style={styles.providerSubtitle}>{option.subtitle}</Text>
-                  </View>
-                  <Ionicons name="chevron-forward" size={20} color="#94a3b8" />
-                </TouchableOpacity>
-              ))}
-            </View>
-            <TouchableOpacity style={styles.modalCancelButton} onPress={() => setImportModalVisible(false)}>
-              <Text style={styles.modalCancelText}>Cancelar</Text>
-            </TouchableOpacity>
+        <Modal
+          visible={importModalVisible}
+          transparent
+          animationType="fade"
+          onRequestClose={() => setImportModalVisible(false)}
+        >
+          <View style={styles.modalOverlay}>
+            <View style={styles.providerModalContent}>
+              <Text style={styles.modalTitle}>Escolha o calendário</Text>
+              <Text style={styles.modalMessage}>Selecione o provedor que deseja importar.</Text>
+              <View style={styles.providerList}>
+                {providerOptions.map((option) => (
+                  <TouchableOpacity
+                    key={option.id}
+                    style={styles.providerOption}
+                    onPress={() => handleSelectProvider(option)}
+                  >
+                    <MaterialCommunityIcons name={option.icon} size={28} color="#264653" />
+                    <View style={styles.providerTexts}>
+                      <Text style={styles.providerTitle}>{option.title}</Text>
+                      <Text style={styles.providerSubtitle}>{option.subtitle}</Text>
+                    </View>
+                    <Ionicons name="chevron-forward" size={20} color="#94a3b8" />
+                  </TouchableOpacity>
+                ))}
+              </View>
+              <TouchableOpacity
+                style={styles.modalCancelButton}
+                onPress={() => setImportModalVisible(false)}
+              >
+                <Text style={styles.modalCancelText}>Cancelar</Text>
+              </TouchableOpacity>
           </View>
         </View>
       </Modal>
@@ -1131,14 +1138,17 @@ export default function ConfigScreen() {
           </View>
         </View>
       </Modal>
-    </ScrollView>
+      </ScrollView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
-  scroll: {
+  screen: {
     flex: 1,
     backgroundColor: "#f4f7fb",
+  },
+  contentContainer: {
     paddingHorizontal: 20,
     paddingTop: 24,
     paddingBottom: 0,

--- a/front/src/screens/TasksScreen.tsx
+++ b/front/src/screens/TasksScreen.tsx
@@ -211,32 +211,32 @@ const TaskCard = ({ task, onEdit }: TaskCardProps) => {
       <View style={[styles.cardAccent, { backgroundColor: calendarColor }]} />
       <View style={styles.cardContent}>
         <View style={styles.cardHeader}>
-          <View style={styles.cardHeaderRight}>
-            {recurring && (
-              <View style={styles.recurringTag}>
-                <Text style={styles.recurringTagText}>Recorrente</Text>
-              </View>
-            )}
-            <View style={[styles.cardCategoryBadge, { backgroundColor: badgeBackground }]}>
-              <View style={[styles.cardCategoryDot, { backgroundColor: calendarColor }]} />
-              <Text style={styles.cardCategoryText}>{categoryLabel}</Text>
-            </View>
-            <Ionicons name="create-outline" size={20} style={styles.cardHeaderIcon} />
-          </View>
           <Text style={styles.cardTitle} numberOfLines={2}>
             {task.titulo}
           </Text>
-        </View>
-        <View style={styles.cardMetaRow}>
-          <Ionicons name="time-outline" size={16} style={styles.metaIcon} />
-          <Text style={styles.cardMetaText}>{formatDuration(tempo)}</Text>
-          <View style={styles.metaDivider} />
-          <Ionicons name="speedometer-outline" size={16} style={styles.metaIcon} />
-          <Text style={styles.cardMetaText}>Dificuldade: {task.dificuldade}</Text>
+          <Ionicons name="create-outline" size={20} style={styles.cardHeaderIcon} />
         </View>
         <View style={styles.cardMetaRow}>
           <Ionicons name="calendar-outline" size={16} style={styles.metaIcon} />
-          <Text style={styles.cardSecondaryText}>{descricao}</Text>
+          <Text style={[styles.cardSecondaryText, styles.cardMetaPrimaryText]}>
+            {descricao}
+          </Text>
+          <View style={styles.metaDivider} />
+          <Ionicons name="time-outline" size={16} style={styles.metaIcon} />
+          <Text style={styles.cardMetaText}>{formatDuration(tempo)}</Text>
+        </View>
+        <View style={[styles.cardMetaRow, styles.cardMetaRowSpacing]}>
+          <Ionicons name="speedometer-outline" size={16} style={styles.metaIcon} />
+          <Text style={styles.cardMetaText}>Dificuldade: {task.dificuldade}</Text>
+          {recurring && (
+            <View style={[styles.recurringTag, styles.metaTag]}>
+              <Text style={styles.recurringTagText}>Recorrente</Text>
+            </View>
+          )}
+          <View style={[styles.cardCategoryBadge, styles.metaTag, { backgroundColor: badgeBackground }]}>
+            <View style={[styles.cardCategoryDot, { backgroundColor: calendarColor }]} />
+            <Text style={styles.cardCategoryText}>{categoryLabel}</Text>
+          </View>
         </View>
       </View>
     </TouchableOpacity>
@@ -421,25 +421,12 @@ export default function TasksScreen() {
   return (
     <View style={styles.container}>
       <View style={styles.header}>
-<<<<<<< HEAD
-<<<<<<< HEAD
-        <View style={styles.headerTexts}>
-          <Text style={styles.title}>Minhas Tarefas</Text>
-          <Text style={styles.subtitle}>
-            Organize e visualize tudo o que precisa fazer
-          </Text>
-        </View>
-        <TouchableOpacity style={styles.addButton} onPress={abrirNovaTarefa}>
-          <Text style={styles.addButtonText}>+ Nova tarefa</Text>
-        </TouchableOpacity>
-=======
-=======
->>>>>>> 6c0a111803a8b5dbb2d0bf6d012e2917d52ab5e0
         <View style={styles.headerTopRow}>
           <Text style={styles.title}>Minhas Tarefas</Text>
           <TouchableOpacity
             style={styles.addButton}
             onPress={abrirNovaTarefa}
+            activeOpacity={0.85}
           >
             <Text style={styles.addButtonText}>+ Nova tarefa</Text>
           </TouchableOpacity>
@@ -447,43 +434,6 @@ export default function TasksScreen() {
         <Text style={styles.subtitle}>
           Organize e visualize tudo o que precisa fazer
         </Text>
-      </View>
-      <View style={styles.filterBarContainer}>
-        <ScrollView
-          horizontal
-          showsHorizontalScrollIndicator={false}
-          contentContainerStyle={styles.filterScrollContent}
-        >
-          {FILTERS.map((filter, index) => {
-            const isActive = filter.key === activeFilter;
-            const isLast = index === FILTERS.length - 1;
-            return (
-              <TouchableOpacity
-                key={filter.key}
-                style={[
-                  styles.filterChip,
-                  isActive ? styles.filterChipActive : undefined,
-                  !isLast ? styles.filterChipSpacing : undefined,
-                ]}
-                onPress={() => setActiveFilter(filter.key)}
-                activeOpacity={0.8}
-              >
-                <Text
-                  style={[
-                    styles.filterChipText,
-                    isActive ? styles.filterChipTextActive : undefined,
-                  ]}
-                >
-                  {filter.label}
-                </Text>
-              </TouchableOpacity>
-            );
-          })}
-        </ScrollView>
-<<<<<<< HEAD
->>>>>>> 1b5d843400ba171fa40b830a49369eea04fd93ee
-=======
->>>>>>> 6c0a111803a8b5dbb2d0bf6d012e2917d52ab5e0
       </View>
       <View style={styles.filterBarContainer}>
         <ScrollView
@@ -555,7 +505,7 @@ const styles = StyleSheet.create({
     backgroundColor: "#e6f4f1",
     paddingHorizontal: 20,
     paddingTop: 24,
-    paddingBottom: 24,
+    paddingBottom: 0,
   },
   header: {
     marginBottom: 16,
@@ -564,30 +514,14 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     alignItems: "flex-end",
     justifyContent: "space-between",
-<<<<<<< HEAD
-<<<<<<< HEAD
-    marginBottom: 16,
-  },
-  headerTexts: {
-    flex: 1,
-    marginRight: 16,
-=======
     gap: 12,
->>>>>>> 1b5d843400ba171fa40b830a49369eea04fd93ee
-=======
-    gap: 12,
->>>>>>> 6c0a111803a8b5dbb2d0bf6d012e2917d52ab5e0
+    marginBottom: 12,
   },
   title: {
     fontSize: 24,
     fontWeight: "700",
     color: "#1f2d3d",
     flex: 1,
-  },
-  subtitle: {
-    marginTop: 4,
-    fontSize: 14,
-    color: "#4b5563",
   },
   subtitle: {
     marginTop: 4,
@@ -685,15 +619,11 @@ const styles = StyleSheet.create({
     padding: 16,
   },
   cardHeader: {
-    flexDirection: "column",
-    alignItems: "flex-start",
-    gap: 12,
-  },
-  cardHeaderRight: {
     flexDirection: "row",
-    alignItems: "center",
-    gap: 8,
-    alignSelf: "flex-end",
+    alignItems: "flex-start",
+    justifyContent: "space-between",
+    gap: 12,
+    marginBottom: 12,
   },
   recurringTag: {
     backgroundColor: "#264653",
@@ -728,16 +658,20 @@ const styles = StyleSheet.create({
     fontSize: 17,
     fontWeight: "700",
     color: "#1f2d3d",
-    alignSelf: "stretch",
+    flex: 1,
   },
   cardHeaderIcon: {
     color: "#1c6b73",
+    marginLeft: 12,
   },
   cardMetaRow: {
     flexDirection: "row",
     alignItems: "center",
     flexWrap: "wrap",
     marginTop: 10,
+  },
+  cardMetaRowSpacing: {
+    marginTop: 8,
   },
   metaIcon: {
     marginRight: 6,
@@ -746,6 +680,10 @@ const styles = StyleSheet.create({
   cardMetaText: {
     fontSize: 14,
     color: "#4b5563",
+    marginRight: 8,
+  },
+  cardMetaPrimaryText: {
+    flexShrink: 1,
     marginRight: 8,
   },
   metaDivider: {
@@ -759,6 +697,9 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: "#4b5563",
     flexShrink: 1,
+  },
+  metaTag: {
+    marginLeft: 12,
   },
 });
 


### PR DESCRIPTION
## Summary
- hide the configuration screen scroll indicator and align its padding with the tasks layout while trimming the gap above the bottom menu
- realign the "Nova tarefa" button and reorder task card metadata so execution details lead, followed by duration, difficulty, and the recurrence/category tags

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2ab52f8f8832f94eeb7e404dec6fa