### PR TITLE
Corrigir mensagem de tarefa em aberto

### DIFF
--- a/front/src/screens/TasksScreen.tsx
+++ b/front/src/screens/TasksScreen.tsx
@@ -197,7 +197,7 @@ const TaskCard = ({ task, onEdit }: TaskCardProps) => {
       : `Execução: ${dataFormatada}`
     : diasEmAberto <= 0
     ? "Criada hoje"
-    : `Em aberto ha ${diasEmAberto} dia${diasEmAberto === 1 ? "" : "s"}`;
+    : `Em aberto há ${diasEmAberto} dia${diasEmAberto === 1 ? "" : "s"}`;
   const calendarColor = normalizeCalendarColor(task.cor ?? DEFAULT_CALENDAR_CATEGORY.color);
   const categoryLabel = getCalendarCategoryLabel(task.cor ?? null);
   const badgeBackground = `${calendarColor}26`;


### PR DESCRIPTION
## Summary
- corrigir a acentuação da mensagem exibida para tarefas em aberto na tela de tarefas

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2d4225f18832fa2fe60d148eb4d4d