### PR TITLE
Update task modal interactions

### DIFF
--- a/front/src/components/TaskModal.tsx
+++ b/front/src/components/TaskModal.tsx
@@ -633,10 +633,11 @@ const styles = StyleSheet.create({
   },
   backButton: {
     marginRight: 10,
-    padding: 4,
+    padding: 8,
   },
   backButtonText: {
-    fontSize: 28,
+    fontSize: 84,
+    lineHeight: 84,
     fontWeight: "600",
   },
   titulo: { flex: 1, fontSize: 18, fontWeight: "bold" },

--- a/front/src/components/TaskModal.tsx
+++ b/front/src/components/TaskModal.tsx
@@ -636,8 +636,8 @@ const styles = StyleSheet.create({
     padding: 8,
   },
   backButtonText: {
-    fontSize: 84,
-    lineHeight: 84,
+    fontSize: 42,
+    lineHeight: 42,
     fontWeight: "600",
   },
   titulo: { flex: 1, fontSize: 18, fontWeight: "bold" },

--- a/front/src/components/TaskModal.tsx
+++ b/front/src/components/TaskModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, { useState, useEffect, useRef, useMemo } from "react";
 import {
   Modal,
   View,
@@ -8,6 +8,7 @@ import {
   StyleSheet,
   Platform,
   ScrollView,
+  Alert,
 } from "react-native";
 import DateTimePicker, { DateTimePickerEvent } from "@react-native-community/datetimepicker";
 
@@ -91,6 +92,8 @@ export default function TaskModal({
   const [tempoExecucao, setTempoExecucao] = useState<number>(15);
   const [mostrarDatePicker, setMostrarDatePicker] = useState(false);
   const [mostrarDuracoes, setMostrarDuracoes] = useState(false);
+  const [mostrarModalInicio, setMostrarModalInicio] = useState(false);
+  const [textoConfirmacao, setTextoConfirmacao] = useState("");
   const dataInputRef = useRef<any>(null);
 
   useEffect(() => {
@@ -111,6 +114,8 @@ export default function TaskModal({
     }
     setMostrarDatePicker(false);
     setMostrarDuracoes(false);
+    setMostrarModalInicio(false);
+    setTextoConfirmacao("");
   }, [initialData, visible]);
 
   const dataSelecionada = data
@@ -196,8 +201,38 @@ export default function TaskModal({
 
   const excluir = async () => {
     if (initialData?.id && onDelete) {
-      await Promise.resolve(onDelete(initialData.id));
-      onClose();
+      const executarExclusao = async () => {
+        await Promise.resolve(onDelete(initialData.id!));
+        onClose();
+      };
+
+      if (Platform.OS === "web") {
+        if (typeof window !== "undefined") {
+          const confirmado = window.confirm("Deseja realmente excluir esta tarefa?");
+          if (confirmado) {
+            await executarExclusao();
+          }
+        }
+        return;
+      }
+
+      Alert.alert(
+        "Confirmar exclusão",
+        "Deseja realmente excluir esta tarefa?",
+        [
+          {
+            text: "Cancelar",
+            style: "cancel",
+          },
+          {
+            text: "Excluir",
+            style: "destructive",
+            onPress: () => {
+              void executarExclusao();
+            },
+          },
+        ]
+      );
     }
   };
 
@@ -206,13 +241,59 @@ export default function TaskModal({
     setMostrarDuracoes(false);
   };
 
+  const horaInicio = useMemo(() => {
+    if (!data) {
+      return "HORA INICIO";
+    }
+    const convertida = new Date(data);
+    if (Number.isNaN(convertida.getTime())) {
+      return "HORA INICIO";
+    }
+    return convertida.toLocaleTimeString("pt-BR", {
+      hour: "2-digit",
+      minute: "2-digit",
+    });
+  }, [data]);
+
+  const fraseConfirmacao = useMemo(() => {
+    const nomeTarefa = titulo || initialData?.titulo || "TAREFA";
+    const duracao = formatarDuracao(tempoExecucao);
+
+    return `Começo ${nomeTarefa} às ${horaInicio}, por ${duracao}, sem distrações. Se eu travar, realizo algumas ações essenciais para essa atividade`;
+  }, [horaInicio, tempoExecucao, titulo, initialData?.titulo]);
+
+  const iniciar = () => {
+    setTextoConfirmacao("");
+    setMostrarModalInicio(true);
+  };
+
+  const confirmarInicio = () => {
+    if (textoConfirmacao.trim() !== fraseConfirmacao) {
+      alert("Confirme a frase exatamente como exibida para iniciar.");
+      return;
+    }
+    setMostrarModalInicio(false);
+    onClose();
+  };
+
   return (
     <Modal visible={visible} animationType="slide" transparent>
       <View style={styles.overlay}>
         <View style={styles.modal}>
-          <Text style={styles.titulo}>
-            {initialData ? "Editar Tarefa" : "Nova Tarefa"}
-          </Text>
+          <View style={styles.header}>
+            {initialData ? (
+              <TouchableOpacity
+                onPress={onClose}
+                style={styles.backButton}
+                accessibilityLabel="Voltar"
+              >
+                <Text style={styles.backButtonText}>←</Text>
+              </TouchableOpacity>
+            ) : null}
+            <Text style={styles.titulo}>
+              {initialData ? initialData.titulo || "Tarefa" : "Nova Tarefa"}
+            </Text>
+          </View>
 
           <View style={styles.field}>
             <Text style={styles.label}>Titulo</Text>
@@ -388,24 +469,68 @@ export default function TaskModal({
           </View>
 
           <View style={styles.btnRow}>
-            <TouchableOpacity style={styles.cancelar} onPress={onClose}>
-              <Text style={{ color: "#333" }}>Cancelar</Text>
-            </TouchableOpacity>
-
             {initialData && onDelete && (
               <TouchableOpacity style={styles.excluir} onPress={excluir}>
                 <Text style={{ color: "#fff" }}>Excluir</Text>
               </TouchableOpacity>
             )}
 
+            <TouchableOpacity
+              style={[styles.iniciar, initialData ? undefined : styles.iniciarFull]}
+              onPress={iniciar}
+            >
+              <Text style={{ color: "#2a9d8f" }}>Iniciar</Text>
+            </TouchableOpacity>
+
             <TouchableOpacity style={styles.salvar} onPress={salvar}>
-              <Text style={{ color: "#fff" }}>
-                {initialData ? "Atualizar" : "Salvar"}
-              </Text>
+              <Text style={{ color: "#fff" }}>Salvar</Text>
             </TouchableOpacity>
           </View>
         </View>
       </View>
+
+      <Modal visible={mostrarModalInicio} animationType="fade" transparent>
+        <View style={styles.overlay}>
+          <View style={styles.modalInicio}>
+            <Text style={styles.tituloModalInicio}>Vamos Começar!</Text>
+            <Text style={styles.textoModalInicio}>
+              Me confirme escrevendo o compromisso no formato:
+            </Text>
+            <Text style={styles.textoExemplo}>
+              "{fraseConfirmacao}"
+            </Text>
+            <TextInput
+              placeholder="Digite a frase exatamente como acima"
+              style={[styles.input, styles.textArea, styles.inputConfirmacao]}
+              multiline
+              value={textoConfirmacao}
+              onChangeText={setTextoConfirmacao}
+            />
+            <View style={styles.btnRowInicio}>
+              <TouchableOpacity
+                style={styles.cancelarInicio}
+                onPress={() => {
+                  setMostrarModalInicio(false);
+                  setTextoConfirmacao("");
+                }}
+              >
+                <Text style={styles.cancelarInicioTexto}>Voltar</Text>
+              </TouchableOpacity>
+              <TouchableOpacity
+                style={
+                  textoConfirmacao.trim() === fraseConfirmacao
+                    ? styles.confirmarInicio
+                    : [styles.confirmarInicio, styles.confirmarInicioDesabilitado]
+                }
+                disabled={textoConfirmacao.trim() !== fraseConfirmacao}
+                onPress={confirmarInicio}
+              >
+                <Text style={styles.confirmarInicioTexto}>Começar</Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </View>
+      </Modal>
     </Modal>
   );
 }
@@ -423,7 +548,19 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     padding: 20,
   },
-  titulo: { fontSize: 18, fontWeight: "bold", marginBottom: 12 },
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 12,
+  },
+  backButton: {
+    marginRight: 10,
+    padding: 4,
+  },
+  backButtonText: {
+    fontSize: 20,
+  },
+  titulo: { flex: 1, fontSize: 18, fontWeight: "bold" },
   field: {
     marginBottom: 16,
   },
@@ -529,24 +666,26 @@ const styles = StyleSheet.create({
   },
   btnRow: {
     flexDirection: "row",
-    justifyContent: "space-between",
+    justifyContent: "flex-end",
     marginTop: 15,
-  },
-  cancelar: {
-    backgroundColor: "#f1f1f1",
-    padding: 10,
-    borderRadius: 6,
-    flex: 1,
-    marginRight: 10,
-    alignItems: "center",
+    gap: 10,
   },
   excluir: {
     backgroundColor: "#e63946",
     padding: 10,
     borderRadius: 6,
     flex: 1,
-    marginRight: 10,
     alignItems: "center",
+  },
+  iniciar: {
+    backgroundColor: "#f1f1f1",
+    padding: 10,
+    borderRadius: 6,
+    flex: 1,
+    alignItems: "center",
+  },
+  iniciarFull: {
+    flex: 1.2,
   },
   salvar: {
     backgroundColor: "#2a9d8f",
@@ -554,5 +693,58 @@ const styles = StyleSheet.create({
     borderRadius: 6,
     flex: 1,
     alignItems: "center",
+  },
+  modalInicio: {
+    width: "90%",
+    backgroundColor: "#fff",
+    borderRadius: 8,
+    padding: 20,
+  },
+  tituloModalInicio: {
+    fontSize: 20,
+    fontWeight: "bold",
+    marginBottom: 12,
+  },
+  textoModalInicio: {
+    fontSize: 14,
+    marginBottom: 10,
+    color: "#333",
+  },
+  textoExemplo: {
+    fontSize: 14,
+    fontStyle: "italic",
+    marginBottom: 12,
+    color: "#2a9d8f",
+  },
+  inputConfirmacao: {
+    minHeight: 120,
+  },
+  btnRowInicio: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    gap: 10,
+    marginTop: 10,
+  },
+  cancelarInicio: {
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+    borderRadius: 6,
+    backgroundColor: "#f1f1f1",
+  },
+  cancelarInicioTexto: {
+    color: "#333",
+  },
+  confirmarInicio: {
+    paddingVertical: 10,
+    paddingHorizontal: 18,
+    borderRadius: 6,
+    backgroundColor: "#2a9d8f",
+  },
+  confirmarInicioDesabilitado: {
+    backgroundColor: "#a7dcd3",
+  },
+  confirmarInicioTexto: {
+    color: "#fff",
+    fontWeight: "bold",
   },
 });

--- a/front/src/components/TaskModal.tsx
+++ b/front/src/components/TaskModal.tsx
@@ -366,10 +366,9 @@ export default function TaskModal({
               >
                 <Text style={styles.backButtonText}>←</Text>
               </TouchableOpacity>
-            ) : null}
-            <Text style={styles.titulo}>
-              {initialData ? initialData.titulo || "Tarefa" : "Nova Tarefa"}
-            </Text>
+            ) : (
+              <Text style={styles.titulo}>Nova Tarefa</Text>
+            )}
           </View>
 
           <View style={styles.field}>


### PR DESCRIPTION
## Summary
- add start confirmation modal with contextual phrase for launching activities
- update task modal header and button layout including back arrow, save label, and new start button
- require confirmation before deleting a task

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68e2e6c656d4832f98d3994c30388202