### PR TITLE
Multi-tenant authentication: email/password + per-tenant social OAuth and tenant admin UI

### DIFF
--- a/back/migrations/005_auth_multi_tenant.sql
+++ b/back/migrations/005_auth_multi_tenant.sql
@@ -1,0 +1,114 @@
+﻿CREATE TABLE IF NOT EXISTS tenants (
+  id CHAR(36) NOT NULL,
+  name VARCHAR(255) NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uniq_tenants_name (name)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS users (
+  id CHAR(36) NOT NULL,
+  tenant_id CHAR(36) NOT NULL,
+  email VARCHAR(255) NOT NULL,
+  password_hash VARCHAR(255) NOT NULL,
+  email_verified TINYINT(1) NOT NULL DEFAULT 0,
+  is_admin TINYINT(1) NOT NULL DEFAULT 0,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uniq_users_tenant_email (tenant_id, email),
+  CONSTRAINT fk_users_tenant FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS social_accounts (
+  id CHAR(36) NOT NULL,
+  tenant_id CHAR(36) NOT NULL,
+  user_id CHAR(36) NOT NULL,
+  provider ENUM('google','microsoft','facebook') NOT NULL,
+  provider_user_id VARCHAR(255) NOT NULL,
+  email VARCHAR(255) NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uniq_social_provider_user (tenant_id, provider, provider_user_id),
+  CONSTRAINT fk_social_accounts_tenant FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE,
+  CONSTRAINT fk_social_accounts_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS tenant_oauth_configs (
+  id CHAR(36) NOT NULL,
+  tenant_id CHAR(36) NOT NULL,
+  provider ENUM('google','microsoft','facebook') NOT NULL,
+  client_id VARCHAR(255) NOT NULL,
+  client_secret_encrypted TEXT NOT NULL,
+  redirect_uris JSON NOT NULL,
+  extra JSON NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uniq_tenant_provider (tenant_id, provider),
+  CONSTRAINT fk_tenant_oauth_configs_tenant FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS refresh_tokens (
+  id CHAR(36) NOT NULL,
+  tenant_id CHAR(36) NOT NULL,
+  user_id CHAR(36) NOT NULL,
+  token_hash VARCHAR(255) NOT NULL,
+  expires_at DATETIME NOT NULL,
+  revoked_at DATETIME NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  INDEX idx_refresh_tokens_user (tenant_id, user_id),
+  CONSTRAINT fk_refresh_tokens_tenant FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE,
+  CONSTRAINT fk_refresh_tokens_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS password_reset_tokens (
+  id CHAR(36) NOT NULL,
+  tenant_id CHAR(36) NOT NULL,
+  user_id CHAR(36) NOT NULL,
+  token_hash VARCHAR(255) NOT NULL,
+  expires_at DATETIME NOT NULL,
+  used_at DATETIME NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  INDEX idx_password_reset_user (tenant_id, user_id),
+  CONSTRAINT fk_password_reset_tenant FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE,
+  CONSTRAINT fk_password_reset_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS oauth_states (
+  id CHAR(36) NOT NULL,
+  tenant_id CHAR(36) NOT NULL,
+  provider ENUM('google','microsoft','facebook') NOT NULL,
+  nonce VARCHAR(128) NOT NULL,
+  redirect_uri VARCHAR(512) NOT NULL,
+  expires_at DATETIME NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  UNIQUE KEY uniq_oauth_state_nonce (nonce),
+  CONSTRAINT fk_oauth_states_tenant FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS oauth_login_codes (
+  id CHAR(36) NOT NULL,
+  tenant_id CHAR(36) NOT NULL,
+  user_id CHAR(36) NOT NULL,
+  expires_at DATETIME NOT NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  CONSTRAINT fk_oauth_login_codes_tenant FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE,
+  CONSTRAINT fk_oauth_login_codes_user FOREIGN KEY (user_id) REFERENCES users (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS audit_logs (
+  id CHAR(36) NOT NULL,
+  tenant_id CHAR(36) NOT NULL,
+  user_id CHAR(36) NULL,
+  action VARCHAR(128) NOT NULL,
+  metadata JSON NULL,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (id),
+  INDEX idx_audit_logs_tenant (tenant_id),
+  CONSTRAINT fk_audit_logs_tenant FOREIGN KEY (tenant_id) REFERENCES tenants (id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/back/migrations/006_add_tenant_to_app_events.sql
+++ b/back/migrations/006_add_tenant_to_app_events.sql
@@ -1,0 +1,4 @@
+﻿ALTER TABLE app_events
+  ADD COLUMN tenant_id CHAR(36) NULL AFTER id;
+
+CREATE INDEX idx_app_events_tenant_updated_at ON app_events (tenant_id, updated_at);

--- a/back/src/config.ts
+++ b/back/src/config.ts
@@ -80,6 +80,14 @@ export const config = {
     database: process.env.DB_NAME ?? "coach",
     connectionLimit: parseInteger(process.env.DB_POOL_LIMIT, 10, { min: 1, max: 100 }),
   },
+  auth: {
+    jwtSecret: process.env.AUTH_JWT_SECRET ?? "change-me",
+    encryptionKey: process.env.AUTH_ENCRYPTION_KEY ?? "",
+    accessTokenTtlSeconds: parseInteger(process.env.AUTH_ACCESS_TTL, 900, { min: 60 }),
+    refreshTokenTtlDays: parseInteger(process.env.AUTH_REFRESH_TTL_DAYS, 30, { min: 1 }),
+    passwordResetTtlMinutes: parseInteger(process.env.AUTH_RESET_TTL_MINUTES, 60, { min: 10 }),
+    issuer: process.env.AUTH_ISSUER ?? "coach-pessoal",
+  },
   google: {
     clientId: process.env.GOOGLE_CLIENT_ID ?? "",
     clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
@@ -118,4 +126,12 @@ if (!config.microsoft.clientId || !config.microsoft.clientSecret) {
   console.warn(
     "[config] MICROSOFT_CLIENT_ID or MICROSOFT_CLIENT_SECRET not set. Outlook exchange will fail until configured."
   );
+}
+
+if (!config.auth.encryptionKey) {
+  console.warn("[config] AUTH_ENCRYPTION_KEY not set. OAuth secrets encryption will fail.");
+}
+
+if (config.auth.jwtSecret === "change-me") {
+  console.warn("[config] AUTH_JWT_SECRET is using the default value. Set a strong secret in production.");
 }

--- a/back/src/middleware/auth.ts
+++ b/back/src/middleware/auth.ts
@@ -1,0 +1,50 @@
+﻿import { Request, Response, NextFunction } from "express";
+import { verifyAccessToken } from "../utils/tokens";
+
+declare module "express-serve-static-core" {
+  interface Request {
+    user?: {
+      id: string;
+      tenantId: string;
+      email: string;
+      isAdmin: boolean;
+    };
+  }
+}
+
+export const requireAuth = (req: Request, res: Response, next: NextFunction) => {
+  const header = typeof req.headers.authorization === "string" ? req.headers.authorization : "";
+  const token = header.startsWith("Bearer ") ? header.slice(7) : "";
+  if (!token) {
+    res.status(401).json({ error: "unauthorized" });
+    return;
+  }
+  const payload = verifyAccessToken(token);
+  if (!payload) {
+    res.status(401).json({ error: "unauthorized" });
+    return;
+  }
+  req.user = {
+    id: payload.sub,
+    tenantId: payload.tenantId,
+    email: payload.email,
+    isAdmin: payload.isAdmin,
+  };
+  next();
+};
+
+export const requireAdmin = (req: Request, res: Response, next: NextFunction) => {
+  if (!req.user?.isAdmin) {
+    res.status(403).json({ error: "forbidden" });
+    return;
+  }
+  next();
+};
+
+export const requireTenantMatch = (req: Request, res: Response, next: NextFunction) => {
+  if (req.user?.tenantId && req.tenantId && req.user.tenantId !== req.tenantId) {
+    res.status(403).json({ error: "forbidden" });
+    return;
+  }
+  next();
+};

--- a/back/src/middleware/requestContext.ts
+++ b/back/src/middleware/requestContext.ts
@@ -1,0 +1,16 @@
+﻿import { Request, Response, NextFunction } from "express";
+import crypto from "crypto";
+
+declare module "express-serve-static-core" {
+  interface Request {
+    requestId?: string;
+  }
+}
+
+export const requestContext = (req: Request, res: Response, next: NextFunction) => {
+  const incomingId = typeof req.headers["x-request-id"] === "string" ? req.headers["x-request-id"] : undefined;
+  const requestId = incomingId && incomingId.trim() ? incomingId.trim() : crypto.randomUUID();
+  req.requestId = requestId;
+  res.setHeader("x-request-id", requestId);
+  next();
+};

--- a/back/src/middleware/tenantContext.ts
+++ b/back/src/middleware/tenantContext.ts
@@ -1,0 +1,18 @@
+﻿import { Request, Response, NextFunction } from "express";
+
+declare module "express-serve-static-core" {
+  interface Request {
+    tenantId?: string;
+  }
+}
+
+export const requireTenant = (req: Request, res: Response, next: NextFunction) => {
+  const tenantHeader = req.headers["x-tenant-id"];
+  const tenantId = typeof tenantHeader === "string" ? tenantHeader.trim() : "";
+  if (!tenantId) {
+    res.status(400).json({ error: "tenant_required", message: "Tenant ID ausente." });
+    return;
+  }
+  req.tenantId = tenantId;
+  next();
+};

--- a/back/src/repositories/authRepository.ts
+++ b/back/src/repositories/authRepository.ts
@@ -1,0 +1,367 @@
+﻿import { v4 as uuid } from "uuid";
+import { withConnection } from "../db";
+
+type TenantRecord = {
+  id: string;
+  name: string;
+  created_at: Date;
+};
+
+type UserRecord = {
+  id: string;
+  tenant_id: string;
+  email: string;
+  password_hash: string;
+  email_verified: number;
+  is_admin: number;
+  created_at: Date;
+  updated_at: Date;
+};
+
+type OAuthConfigRecord = {
+  id: string;
+  tenant_id: string;
+  provider: "google" | "microsoft" | "facebook";
+  client_id: string;
+  client_secret_encrypted: string;
+  redirect_uris: string;
+  extra: string | null;
+  created_at: Date;
+  updated_at: Date;
+};
+
+type SocialAccountRecord = {
+  id: string;
+  tenant_id: string;
+  user_id: string;
+  provider: "google" | "microsoft" | "facebook";
+  provider_user_id: string;
+  email: string | null;
+  created_at: Date;
+};
+
+type RefreshTokenRecord = {
+  id: string;
+  tenant_id: string;
+  user_id: string;
+  token_hash: string;
+  expires_at: Date;
+  revoked_at: Date | null;
+  created_at: Date;
+};
+
+type PasswordResetRecord = {
+  id: string;
+  tenant_id: string;
+  user_id: string;
+  token_hash: string;
+  expires_at: Date;
+  used_at: Date | null;
+  created_at: Date;
+};
+
+type OAuthStateRecord = {
+  id: string;
+  tenant_id: string;
+  provider: "google" | "microsoft" | "facebook";
+  nonce: string;
+  redirect_uri: string;
+  expires_at: Date;
+  created_at: Date;
+};
+
+type OAuthLoginCodeRecord = {
+  id: string;
+  tenant_id: string;
+  user_id: string;
+  expires_at: Date;
+  created_at: Date;
+};
+
+export const authRepository = {
+  async createTenant(name: string) {
+    const id = uuid();
+    await withConnection((conn) =>
+      conn.execute("INSERT INTO tenants (id, name) VALUES (?, ?)", [id, name])
+    );
+    return this.findTenantById(id);
+  },
+  async findTenantById(id: string): Promise<TenantRecord | null> {
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute("SELECT * FROM tenants WHERE id = ?", [id]);
+      const record = (rows as TenantRecord[])[0];
+      return record ?? null;
+    });
+  },
+  async createUser(params: {
+    tenantId: string;
+    email: string;
+    passwordHash: string;
+    isAdmin?: boolean;
+    emailVerified?: boolean;
+  }) {
+    const id = uuid();
+    const { tenantId, email, passwordHash, isAdmin = false, emailVerified = false } = params;
+    await withConnection((conn) =>
+      conn.execute(
+        "INSERT INTO users (id, tenant_id, email, password_hash, is_admin, email_verified) VALUES (?, ?, ?, ?, ?, ?)",
+        [id, tenantId, email, passwordHash, isAdmin ? 1 : 0, emailVerified ? 1 : 0]
+      )
+    );
+    return this.findUserById(id);
+  },
+  async findUserByEmail(tenantId: string, email: string): Promise<UserRecord | null> {
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute("SELECT * FROM users WHERE tenant_id = ? AND email = ?", [
+        tenantId,
+        email,
+      ]);
+      return (rows as UserRecord[])[0] ?? null;
+    });
+  },
+  async findUserById(id: string): Promise<UserRecord | null> {
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute("SELECT * FROM users WHERE id = ?", [id]);
+      return (rows as UserRecord[])[0] ?? null;
+    });
+  },
+  async updateUserPassword(id: string, passwordHash: string) {
+    await withConnection((conn) =>
+      conn.execute("UPDATE users SET password_hash = ? WHERE id = ?", [passwordHash, id])
+    );
+  },
+  async markEmailVerified(id: string) {
+    await withConnection((conn) =>
+      conn.execute("UPDATE users SET email_verified = 1 WHERE id = ?", [id])
+    );
+  },
+  async createSocialAccount(params: {
+    tenantId: string;
+    userId: string;
+    provider: "google" | "microsoft" | "facebook";
+    providerUserId: string;
+    email: string | null;
+  }) {
+    const id = uuid();
+    const { tenantId, userId, provider, providerUserId, email } = params;
+    await withConnection((conn) =>
+      conn.execute(
+        "INSERT INTO social_accounts (id, tenant_id, user_id, provider, provider_user_id, email) VALUES (?, ?, ?, ?, ?, ?)",
+        [id, tenantId, userId, provider, providerUserId, email]
+      )
+    );
+    return this.findSocialAccountById(id);
+  },
+  async findSocialAccountById(id: string): Promise<SocialAccountRecord | null> {
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute("SELECT * FROM social_accounts WHERE id = ?", [id]);
+      return (rows as SocialAccountRecord[])[0] ?? null;
+    });
+  },
+  async findSocialAccountByProviderId(params: {
+    tenantId: string;
+    provider: "google" | "microsoft" | "facebook";
+    providerUserId: string;
+  }): Promise<SocialAccountRecord | null> {
+    const { tenantId, provider, providerUserId } = params;
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute(
+        "SELECT * FROM social_accounts WHERE tenant_id = ? AND provider = ? AND provider_user_id = ?",
+        [tenantId, provider, providerUserId]
+      );
+      return (rows as SocialAccountRecord[])[0] ?? null;
+    });
+  },
+  async findSocialAccountByUser(params: {
+    tenantId: string;
+    userId: string;
+    provider: "google" | "microsoft" | "facebook";
+  }): Promise<SocialAccountRecord | null> {
+    const { tenantId, userId, provider } = params;
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute(
+        "SELECT * FROM social_accounts WHERE tenant_id = ? AND user_id = ? AND provider = ?",
+        [tenantId, userId, provider]
+      );
+      return (rows as SocialAccountRecord[])[0] ?? null;
+    });
+  },
+  async deleteSocialAccount(id: string) {
+    await withConnection((conn) => conn.execute("DELETE FROM social_accounts WHERE id = ?", [id]));
+  },
+  async upsertTenantOAuthConfig(params: {
+    tenantId: string;
+    provider: "google" | "microsoft" | "facebook";
+    clientId: string;
+    clientSecretEncrypted: string;
+    redirectUris: string[];
+    extra: Record<string, unknown> | null;
+  }) {
+    const { tenantId, provider, clientId, clientSecretEncrypted, redirectUris, extra } = params;
+    const existing = await this.getTenantOAuthConfig(tenantId, provider);
+    if (existing) {
+      await withConnection((conn) =>
+        conn.execute(
+          "UPDATE tenant_oauth_configs SET client_id = ?, client_secret_encrypted = ?, redirect_uris = ?, extra = ? WHERE id = ?",
+          [clientId, clientSecretEncrypted, JSON.stringify(redirectUris), extra ? JSON.stringify(extra) : null, existing.id]
+        )
+      );
+      return this.getTenantOAuthConfig(tenantId, provider);
+    }
+    const id = uuid();
+    await withConnection((conn) =>
+      conn.execute(
+        "INSERT INTO tenant_oauth_configs (id, tenant_id, provider, client_id, client_secret_encrypted, redirect_uris, extra) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        [id, tenantId, provider, clientId, clientSecretEncrypted, JSON.stringify(redirectUris), extra ? JSON.stringify(extra) : null]
+      )
+    );
+    return this.getTenantOAuthConfig(tenantId, provider);
+  },
+  async getTenantOAuthConfig(tenantId: string, provider: "google" | "microsoft" | "facebook") {
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute(
+        "SELECT * FROM tenant_oauth_configs WHERE tenant_id = ? AND provider = ?",
+        [tenantId, provider]
+      );
+      return (rows as OAuthConfigRecord[])[0] ?? null;
+    });
+  },
+  async listTenantOAuthStatus(tenantId: string) {
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute("SELECT provider, client_id FROM tenant_oauth_configs WHERE tenant_id = ?", [
+        tenantId,
+      ]);
+      return rows as { provider: "google" | "microsoft" | "facebook"; client_id: string }[];
+    });
+  },
+  async createRefreshToken(params: { tenantId: string; userId: string; tokenHash: string; expiresAt: Date }) {
+    const id = uuid();
+    const { tenantId, userId, tokenHash, expiresAt } = params;
+    await withConnection((conn) =>
+      conn.execute(
+        "INSERT INTO refresh_tokens (id, tenant_id, user_id, token_hash, expires_at) VALUES (?, ?, ?, ?, ?)",
+        [id, tenantId, userId, tokenHash, expiresAt]
+      )
+    );
+    return this.findRefreshToken(id);
+  },
+  async findRefreshToken(id: string): Promise<RefreshTokenRecord | null> {
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute("SELECT * FROM refresh_tokens WHERE id = ?", [id]);
+      return (rows as RefreshTokenRecord[])[0] ?? null;
+    });
+  },
+  async findRefreshTokenByHash(tenantId: string, tokenHash: string): Promise<RefreshTokenRecord | null> {
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute(
+        "SELECT * FROM refresh_tokens WHERE tenant_id = ? AND token_hash = ?",
+        [tenantId, tokenHash]
+      );
+      return (rows as RefreshTokenRecord[])[0] ?? null;
+    });
+  },
+  async revokeRefreshTokensForUser(tenantId: string, userId: string) {
+    await withConnection((conn) =>
+      conn.execute("UPDATE refresh_tokens SET revoked_at = NOW() WHERE tenant_id = ? AND user_id = ?", [
+        tenantId,
+        userId,
+      ])
+    );
+  },
+  async revokeRefreshTokenById(id: string) {
+    await withConnection((conn) =>
+      conn.execute("UPDATE refresh_tokens SET revoked_at = NOW() WHERE id = ?", [id])
+    );
+  },
+  async createPasswordResetToken(params: {
+    tenantId: string;
+    userId: string;
+    tokenHash: string;
+    expiresAt: Date;
+  }) {
+    const id = uuid();
+    const { tenantId, userId, tokenHash, expiresAt } = params;
+    await withConnection((conn) =>
+      conn.execute(
+        "INSERT INTO password_reset_tokens (id, tenant_id, user_id, token_hash, expires_at) VALUES (?, ?, ?, ?, ?)",
+        [id, tenantId, userId, tokenHash, expiresAt]
+      )
+    );
+    return id;
+  },
+  async findPasswordResetByHash(tenantId: string, tokenHash: string): Promise<PasswordResetRecord | null> {
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute(
+        "SELECT * FROM password_reset_tokens WHERE tenant_id = ? AND token_hash = ?",
+        [tenantId, tokenHash]
+      );
+      return (rows as PasswordResetRecord[])[0] ?? null;
+    });
+  },
+  async markPasswordResetUsed(id: string) {
+    await withConnection((conn) =>
+      conn.execute("UPDATE password_reset_tokens SET used_at = NOW() WHERE id = ?", [id])
+    );
+  },
+  async createOAuthState(params: {
+    tenantId: string;
+    provider: "google" | "microsoft" | "facebook";
+    nonce: string;
+    redirectUri: string;
+    expiresAt: Date;
+  }) {
+    const id = uuid();
+    const { tenantId, provider, nonce, redirectUri, expiresAt } = params;
+    await withConnection((conn) =>
+      conn.execute(
+        "INSERT INTO oauth_states (id, tenant_id, provider, nonce, redirect_uri, expires_at) VALUES (?, ?, ?, ?, ?, ?)",
+        [id, tenantId, provider, nonce, redirectUri, expiresAt]
+      )
+    );
+    return id;
+  },
+  async findOAuthState(nonce: string): Promise<OAuthStateRecord | null> {
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute("SELECT * FROM oauth_states WHERE nonce = ?", [nonce]);
+      return (rows as OAuthStateRecord[])[0] ?? null;
+    });
+  },
+  async deleteOAuthState(id: string) {
+    await withConnection((conn) => conn.execute("DELETE FROM oauth_states WHERE id = ?", [id]));
+  },
+  async createOAuthLoginCode(params: { tenantId: string; userId: string; expiresAt: Date }) {
+    const id = uuid();
+    const { tenantId, userId, expiresAt } = params;
+    await withConnection((conn) =>
+      conn.execute("INSERT INTO oauth_login_codes (id, tenant_id, user_id, expires_at) VALUES (?, ?, ?, ?)", [
+        id,
+        tenantId,
+        userId,
+        expiresAt,
+      ])
+    );
+    return id;
+  },
+  async findOAuthLoginCode(id: string): Promise<OAuthLoginCodeRecord | null> {
+    return withConnection(async (conn) => {
+      const [rows] = await conn.execute("SELECT * FROM oauth_login_codes WHERE id = ?", [id]);
+      return (rows as OAuthLoginCodeRecord[])[0] ?? null;
+    });
+  },
+  async deleteOAuthLoginCode(id: string) {
+    await withConnection((conn) => conn.execute("DELETE FROM oauth_login_codes WHERE id = ?", [id]));
+  },
+  async createAuditLog(params: { tenantId: string; userId: string | null; action: string; metadata?: any }) {
+    const id = uuid();
+    const { tenantId, userId, action, metadata } = params;
+    await withConnection((conn) =>
+      conn.execute("INSERT INTO audit_logs (id, tenant_id, user_id, action, metadata) VALUES (?, ?, ?, ?, ?)", [
+        id,
+        tenantId,
+        userId,
+        action,
+        metadata ? JSON.stringify(metadata) : null,
+      ])
+    );
+  },
+};

--- a/back/src/services/emailService.ts
+++ b/back/src/services/emailService.ts
@@ -1,0 +1,14 @@
+﻿type ResetEmailPayload = {
+  to: string;
+  resetToken: string;
+  tenantId: string;
+};
+
+export const sendPasswordResetEmail = async (payload: ResetEmailPayload) => {
+  const { to, resetToken, tenantId } = payload;
+  console.log("[email] password reset requested", {
+    tenantId,
+    to,
+    resetTokenMasked: `${resetToken.slice(0, 6)}...${resetToken.slice(-4)}`,
+  });
+};

--- a/back/src/services/oauthProviders.ts
+++ b/back/src/services/oauthProviders.ts
@@ -1,0 +1,127 @@
+﻿import axios from "axios";
+import { decryptSecret } from "../utils/crypto";
+
+export type OAuthProvider = "google" | "microsoft" | "facebook";
+
+export type TenantOAuthConfig = {
+  clientId: string;
+  clientSecretEncrypted: string;
+  redirectUris: string[];
+  extra: Record<string, unknown> | null;
+};
+
+export type OAuthProfile = {
+  providerUserId: string;
+  email: string | null;
+  emailVerified: boolean;
+  name: string | null;
+};
+
+const getSecret = (config: TenantOAuthConfig) => decryptSecret(config.clientSecretEncrypted);
+
+export const buildAuthUrl = (provider: OAuthProvider, config: TenantOAuthConfig, redirectUri: string, state: string) => {
+  if (provider === "google") {
+    const params = new URLSearchParams({
+      client_id: config.clientId,
+      redirect_uri: redirectUri,
+      response_type: "code",
+      scope: "openid email profile",
+      access_type: "offline",
+      prompt: "consent",
+      state,
+    });
+    return `https://accounts.google.com/o/oauth2/v2/auth?${params.toString()}`;
+  }
+  if (provider === "microsoft") {
+    const params = new URLSearchParams({
+      client_id: config.clientId,
+      redirect_uri: redirectUri,
+      response_type: "code",
+      response_mode: "query",
+      scope: "openid email profile offline_access",
+      state,
+    });
+    return `https://login.microsoftonline.com/common/oauth2/v2.0/authorize?${params.toString()}`;
+  }
+  const params = new URLSearchParams({
+    client_id: config.clientId,
+    redirect_uri: redirectUri,
+    response_type: "code",
+    scope: "email,public_profile",
+    state,
+  });
+  return `https://www.facebook.com/v18.0/dialog/oauth?${params.toString()}`;
+};
+
+export const exchangeCodeForProfile = async (
+  provider: OAuthProvider,
+  config: TenantOAuthConfig,
+  code: string,
+  redirectUri: string
+): Promise<OAuthProfile> => {
+  if (provider === "google") {
+    const tokenResponse = await axios.post(
+      "https://oauth2.googleapis.com/token",
+      new URLSearchParams({
+        code,
+        client_id: config.clientId,
+        client_secret: getSecret(config),
+        redirect_uri: redirectUri,
+        grant_type: "authorization_code",
+      }).toString(),
+      { headers: { "content-type": "application/x-www-form-urlencoded" } }
+    );
+    const accessToken = tokenResponse.data.access_token as string;
+    const userinfo = await axios.get("https://openidconnect.googleapis.com/v1/userinfo", {
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+    return {
+      providerUserId: userinfo.data.sub,
+      email: userinfo.data.email ?? null,
+      emailVerified: Boolean(userinfo.data.email_verified),
+      name: userinfo.data.name ?? null,
+    };
+  }
+  if (provider === "microsoft") {
+    const tokenResponse = await axios.post(
+      "https://login.microsoftonline.com/common/oauth2/v2.0/token",
+      new URLSearchParams({
+        code,
+        client_id: config.clientId,
+        client_secret: getSecret(config),
+        redirect_uri: redirectUri,
+        grant_type: "authorization_code",
+        scope: "openid email profile offline_access",
+      }).toString(),
+      { headers: { "content-type": "application/x-www-form-urlencoded" } }
+    );
+    const accessToken = tokenResponse.data.access_token as string;
+    const profileResponse = await axios.get("https://graph.microsoft.com/v1.0/me", {
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+    return {
+      providerUserId: profileResponse.data.id,
+      email: profileResponse.data.mail ?? profileResponse.data.userPrincipalName ?? null,
+      emailVerified: true,
+      name: profileResponse.data.displayName ?? null,
+    };
+  }
+  const tokenResponse = await axios.get("https://graph.facebook.com/v18.0/oauth/access_token", {
+    params: {
+      client_id: config.clientId,
+      client_secret: getSecret(config),
+      redirect_uri: redirectUri,
+      code,
+    },
+  });
+  const accessToken = tokenResponse.data.access_token as string;
+  const profileResponse = await axios.get("https://graph.facebook.com/me", {
+    params: { fields: "id,name,email", access_token: accessToken },
+  });
+  return {
+    providerUserId: profileResponse.data.id,
+    email: profileResponse.data.email ?? null,
+    emailVerified: Boolean(profileResponse.data.email),
+    name: profileResponse.data.name ?? null,
+  };
+};

--- a/back/src/utils/crypto.ts
+++ b/back/src/utils/crypto.ts
@@ -1,0 +1,32 @@
+﻿import crypto from "crypto";
+import { config } from "../config";
+
+const ALGO = "aes-256-gcm";
+const IV_LENGTH = 12;
+
+const getKey = () => {
+  const key = Buffer.from(config.auth.encryptionKey, "base64");
+  if (key.length !== 32) {
+    throw new Error("Invalid encryption key length. Must be 32 bytes (base64).");
+  }
+  return key;
+};
+
+export const encryptSecret = (plainText: string): string => {
+  const iv = crypto.randomBytes(IV_LENGTH);
+  const cipher = crypto.createCipheriv(ALGO, getKey(), iv);
+  const encrypted = Buffer.concat([cipher.update(plainText, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, encrypted]).toString("base64");
+};
+
+export const decryptSecret = (payload: string): string => {
+  const data = Buffer.from(payload, "base64");
+  const iv = data.subarray(0, IV_LENGTH);
+  const tag = data.subarray(IV_LENGTH, IV_LENGTH + 16);
+  const encrypted = data.subarray(IV_LENGTH + 16);
+  const decipher = crypto.createDecipheriv(ALGO, getKey(), iv);
+  decipher.setAuthTag(tag);
+  const decrypted = Buffer.concat([decipher.update(encrypted), decipher.final()]);
+  return decrypted.toString("utf8");
+};

--- a/back/src/utils/passwords.ts
+++ b/back/src/utils/passwords.ts
@@ -1,0 +1,31 @@
+﻿import crypto from "crypto";
+
+const SALT_LENGTH = 16;
+const KEY_LENGTH = 64;
+const COST = 64 * 1024;
+const BLOCK_SIZE = 8;
+const PARALLELIZATION = 1;
+
+export const hashPassword = (password: string): string => {
+  const salt = crypto.randomBytes(SALT_LENGTH);
+  const derived = crypto.scryptSync(password, salt, KEY_LENGTH, {
+    N: COST,
+    r: BLOCK_SIZE,
+    p: PARALLELIZATION,
+  });
+  return `${salt.toString("hex")}:${derived.toString("hex")}`;
+};
+
+export const verifyPassword = (password: string, stored: string): boolean => {
+  const [saltHex, hashHex] = stored.split(":");
+  if (!saltHex || !hashHex) {
+    return false;
+  }
+  const salt = Buffer.from(saltHex, "hex");
+  const derived = crypto.scryptSync(password, salt, KEY_LENGTH, {
+    N: COST,
+    r: BLOCK_SIZE,
+    p: PARALLELIZATION,
+  });
+  return crypto.timingSafeEqual(Buffer.from(hashHex, "hex"), derived);
+};

--- a/back/src/utils/tokens.ts
+++ b/back/src/utils/tokens.ts
@@ -1,0 +1,56 @@
+﻿import crypto from "crypto";
+import { config } from "../config";
+
+type JwtPayload = {
+  sub: string;
+  tenantId: string;
+  email: string;
+  isAdmin: boolean;
+  exp: number;
+  iat: number;
+};
+
+const base64Url = (input: Buffer | string) => {
+  const buffer = Buffer.isBuffer(input) ? input : Buffer.from(input, "utf8");
+  return buffer
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+};
+
+const sign = (data: string) => {
+  return base64Url(crypto.createHmac("sha256", config.auth.jwtSecret).update(data).digest());
+};
+
+export const createAccessToken = (payload: Omit<JwtPayload, "exp" | "iat">, ttlSeconds: number) => {
+  const iat = Math.floor(Date.now() / 1000);
+  const exp = iat + ttlSeconds;
+  const header = base64Url(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+  const body = base64Url(JSON.stringify({ ...payload, iat, exp }));
+  const signature = sign(`${header}.${body}`);
+  return `${header}.${body}.${signature}`;
+};
+
+export const verifyAccessToken = (token: string): JwtPayload | null => {
+  const [header, body, signature] = token.split(".");
+  if (!header || !body || !signature) {
+    return null;
+  }
+  const expected = sign(`${header}.${body}`);
+  if (!crypto.timingSafeEqual(Buffer.from(signature), Buffer.from(expected))) {
+    return null;
+  }
+  try {
+    const decoded = JSON.parse(Buffer.from(body.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8"));
+    if (!decoded.exp || typeof decoded.exp !== "number") {
+      return null;
+    }
+    if (decoded.exp < Math.floor(Date.now() / 1000)) {
+      return null;
+    }
+    return decoded as JwtPayload;
+  } catch {
+    return null;
+  }
+};

--- a/front/src/App.tsx
+++ b/front/src/App.tsx
@@ -1,15 +1,31 @@
 ﻿import React, { useEffect, useState } from "react";
 import { View, Text, TouchableOpacity, StyleSheet } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
+import * as AuthSession from "expo-auth-session";
 import AgendaScreen from "./screens/AgendaScreen";
 import TasksScreen from "./screens/TasksScreen";
 import ConfigScreen from "./screens/ConfigScreen";
+import LoginScreen from "./screens/LoginScreen";
+import SignUpScreen from "./screens/SignUpScreen";
 import { initializeCalendarAccounts } from "./services/calendarAccountsStore";
 import { initializeCalendarSyncEngine } from "./services/calendarSyncManager";
 import { initializeEventSync } from "./services/eventSync";
 import { PomodoroProvider } from "./pomodoro/PomodoroProvider";
+import {
+  completeSocialLogin,
+  fetchProviderStatus,
+  getStoredTokens,
+  getTenantId,
+  login,
+  register,
+  requestPasswordReset,
+  setTenantId,
+  startSocialLogin,
+  storeTokens,
+} from "./services/authService";
 
 type Tela = "chat" | "agenda" | "tarefas" | "config";
+type AuthMode = "login" | "signup";
 
 type IoniconName = keyof typeof Ionicons.glyphMap;
 
@@ -47,6 +63,12 @@ const menuOptions: {
 
 export default function App() {
   const [tela, setTela] = useState<Tela>("chat");
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [authMode, setAuthMode] = useState<AuthMode>("login");
+  const [tenantId, setTenantIdState] = useState("");
+  const [providerStatus, setProviderStatus] = useState<
+    { provider: "google" | "microsoft" | "facebook"; configured: boolean }[]
+  >([]);
 
   useEffect(() => {
     initializeEventSync();
@@ -59,6 +81,36 @@ export default function App() {
       }
     })();
   }, []);
+
+  useEffect(() => {
+    (async () => {
+      const storedTenantId = await getTenantId();
+      if (storedTenantId) {
+        setTenantIdState(storedTenantId);
+      }
+      const tokens = await getStoredTokens();
+      if (tokens?.accessToken) {
+        setIsAuthenticated(true);
+      }
+    })();
+  }, []);
+
+  useEffect(() => {
+    if (!tenantId) {
+      setProviderStatus([]);
+      return;
+    }
+    fetchProviderStatus(tenantId)
+      .then((data) => {
+        setProviderStatus(
+          data.providers.map((item) => ({
+            provider: item.provider as "google" | "microsoft" | "facebook",
+            configured: item.configured,
+          }))
+        );
+      })
+      .catch(() => setProviderStatus([]));
+  }, [tenantId]);
 
   const renderConteudo = () => {
     switch (tela) {
@@ -79,6 +131,73 @@ export default function App() {
         );
     }
   };
+
+  const handleLogin = async (email: string, password: string) => {
+    if (!tenantId) {
+      throw new Error("Informe o Tenant ID.");
+    }
+    await setTenantId(tenantId);
+    const tokens = await login(tenantId, email, password);
+    await storeTokens(tokens);
+    setIsAuthenticated(true);
+  };
+
+  const handleRegister = async (email: string, password: string) => {
+    if (!tenantId) {
+      throw new Error("Informe o Tenant ID.");
+    }
+    await setTenantId(tenantId);
+    const tokens = await register(tenantId, email, password);
+    await storeTokens(tokens);
+    setIsAuthenticated(true);
+  };
+
+  const handleSocialLogin = async (provider: "google" | "microsoft" | "facebook") => {
+    if (!tenantId) {
+      throw new Error("Informe o Tenant ID.");
+    }
+    await setTenantId(tenantId);
+    const redirectUri = AuthSession.makeRedirectUri();
+    const { authUrl } = await startSocialLogin(tenantId, provider, redirectUri);
+    const result = await AuthSession.startAsync({ authUrl, returnUrl: redirectUri });
+    if (result.type !== "success" || !("code" in result.params)) {
+      throw new Error("Login social cancelado.");
+    }
+    const tokens = await completeSocialLogin(tenantId, String(result.params.code));
+    await storeTokens(tokens);
+    setIsAuthenticated(true);
+  };
+
+  const handleForgotPassword = async (email: string) => {
+    if (!tenantId) {
+      throw new Error("Informe o Tenant ID.");
+    }
+    await requestPasswordReset(tenantId, email);
+  };
+
+  if (!isAuthenticated) {
+    if (authMode === "signup") {
+      return (
+        <SignUpScreen
+          tenantId={tenantId}
+          onTenantChange={setTenantIdState}
+          onSignUp={handleRegister}
+          onBack={() => setAuthMode("login")}
+        />
+      );
+    }
+    return (
+      <LoginScreen
+        tenantId={tenantId}
+        onTenantChange={setTenantIdState}
+        onLogin={handleLogin}
+        onForgotPassword={handleForgotPassword}
+        onSignupPress={() => setAuthMode("signup")}
+        onSocialLogin={handleSocialLogin}
+        providers={providerStatus}
+      />
+    );
+  }
 
   return (
     <PomodoroProvider>
@@ -149,7 +268,3 @@ const styles = StyleSheet.create({
   menuTexto: { fontSize: 12, marginTop: 2, color: "#7a7a7a" },
   menuTextoAtivo: { color: "#264653", fontWeight: "600" },
 });
-
-
-
-

--- a/front/src/screens/LoginScreen.tsx
+++ b/front/src/screens/LoginScreen.tsx
@@ -1,0 +1,314 @@
+import React, { useMemo, useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  ActivityIndicator,
+} from "react-native";
+import { Ionicons } from "@expo/vector-icons";
+
+type Props = {
+  tenantId: string;
+  onTenantChange: (value: string) => void;
+  onLogin: (email: string, password: string) => Promise<void>;
+  onForgotPassword: (email: string) => Promise<void>;
+  onSignupPress: () => void;
+  onSocialLogin: (provider: "google" | "microsoft" | "facebook") => Promise<void>;
+  providers: { provider: "google" | "microsoft" | "facebook"; configured: boolean }[];
+};
+
+export default function LoginScreen({
+  tenantId,
+  onTenantChange,
+  onLogin,
+  onForgotPassword,
+  onSignupPress,
+  onSocialLogin,
+  providers,
+}: Props) {
+  const [email, setEmail] = useState("");
+  const [senha, setSenha] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+  const providerMap = useMemo(
+    () =>
+      providers.reduce(
+        (acc, item) => {
+          acc[item.provider] = item.configured;
+          return acc;
+        },
+        {} as Record<"google" | "microsoft" | "facebook", boolean>
+      ),
+    [providers]
+  );
+
+  const handleLogin = async () => {
+    setLoading(true);
+    setMessage(null);
+    try {
+      await onLogin(email, senha);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Falha ao entrar.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleForgot = async () => {
+    setLoading(true);
+    setMessage(null);
+    try {
+      await onForgotPassword(email);
+      setMessage("Se existir uma conta, enviamos as instrucoes de reset.");
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Falha ao solicitar reset.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSocial = async (provider: "google" | "microsoft" | "facebook") => {
+    setLoading(true);
+    setMessage(null);
+    try {
+      await onSocialLogin(provider);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Falha no login social.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.titulo}>Bem-vindo(a)</Text>
+        <Text style={styles.subtitulo}>
+          Acesse sua conta para continuar sua jornada com o Coach Pessoal.
+        </Text>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.secaoTitulo}>Entrar com email e senha</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Tenant ID"
+          value={tenantId}
+          onChangeText={onTenantChange}
+          autoCapitalize="none"
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Email"
+          value={email}
+          onChangeText={setEmail}
+          autoCapitalize="none"
+          keyboardType="email-address"
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Senha"
+          value={senha}
+          onChangeText={setSenha}
+          secureTextEntry
+        />
+        <TouchableOpacity style={styles.acaoPrimaria} onPress={handleLogin} disabled={loading}>
+          {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.acaoPrimariaTexto}>Entrar</Text>}
+        </TouchableOpacity>
+        <TouchableOpacity onPress={handleForgot} disabled={loading}>
+          <Text style={styles.link}>Esqueceu sua senha?</Text>
+        </TouchableOpacity>
+        {message ? <Text style={styles.feedback}>{message}</Text> : null}
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.secaoTitulo}>Ou use login social</Text>
+        <TouchableOpacity
+          style={[styles.socialButton, styles.googleButton]}
+          onPress={() => handleSocial("google")}
+          disabled={!providerMap.google || loading}
+        >
+          <Ionicons name="logo-google" size={20} color="#db4437" />
+          <Text style={styles.socialText}>Continuar com Google</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.socialButton, styles.microsoftButton]}
+          onPress={() => handleSocial("microsoft")}
+          disabled={!providerMap.microsoft || loading}
+        >
+          <Ionicons name="logo-windows" size={20} color="#2563eb" />
+          <Text style={styles.socialText}>Continuar com Microsoft</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={[styles.socialButton, styles.facebookButton]}
+          onPress={() => handleSocial("facebook")}
+          disabled={!providerMap.facebook || loading}
+        >
+          <Ionicons name="logo-facebook" size={20} color="#1877f2" />
+          <Text style={styles.socialText}>Continuar com Facebook</Text>
+        </TouchableOpacity>
+        <Text style={styles.hint}>
+          Os botoes ficam disponiveis somente quando o tenant possui credenciais configuradas.
+        </Text>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.secaoTitulo}>Ainda nao tem conta?</Text>
+        <Text style={styles.secaoTexto}>
+          Crie sua conta com email e senha para começar.
+        </Text>
+        <TouchableOpacity style={styles.acaoSecundaria} onPress={onSignupPress}>
+          <Text style={styles.acaoSecundariaTexto}>Criar conta</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={styles.alerta}>
+        <Text style={styles.alertaTitulo}>Privacidade e seguranca</Text>
+        <Text style={styles.alertaTexto}>
+          Toda configuracao de integracao e acesso e feita pelo proprio usuario.
+          Nenhum usuario tem acesso a informacoes de outros usuarios, garantindo
+          isolamento total dos dados e evitando falhas de seguranca.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    padding: 20,
+    backgroundColor: "#f6f7f9",
+  },
+  header: {
+    marginBottom: 20,
+  },
+  titulo: {
+    fontSize: 28,
+    fontWeight: "700",
+    color: "#264653",
+  },
+  subtitulo: {
+    fontSize: 15,
+    color: "#6b7280",
+    marginTop: 6,
+  },
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: "#000",
+    shadowOpacity: 0.05,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 2,
+  },
+  secaoTitulo: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#1f2937",
+    marginBottom: 10,
+  },
+  secaoTexto: {
+    fontSize: 14,
+    color: "#6b7280",
+    marginBottom: 12,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 15,
+    marginBottom: 10,
+    backgroundColor: "#f9fafb",
+  },
+  acaoPrimaria: {
+    backgroundColor: "#264653",
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+    marginTop: 6,
+  },
+  acaoPrimariaTexto: {
+    color: "#fff",
+    fontWeight: "600",
+  },
+  link: {
+    marginTop: 10,
+    color: "#2563eb",
+    fontWeight: "500",
+    textAlign: "center",
+  },
+  socialButton: {
+    flexDirection: "row",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#e5e7eb",
+    paddingVertical: 12,
+    paddingHorizontal: 14,
+    borderRadius: 8,
+    marginBottom: 10,
+    backgroundColor: "#fff",
+  },
+  socialText: {
+    marginLeft: 10,
+    fontSize: 15,
+    fontWeight: "500",
+    color: "#111827",
+  },
+  googleButton: {
+    borderColor: "#f3d2cf",
+  },
+  microsoftButton: {
+    borderColor: "#c7d2fe",
+  },
+  facebookButton: {
+    borderColor: "#c7dcff",
+  },
+  acaoSecundaria: {
+    backgroundColor: "#e6f4f1",
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+    marginTop: 6,
+  },
+  acaoSecundariaTexto: {
+    color: "#0f766e",
+    fontWeight: "600",
+  },
+  alerta: {
+    padding: 16,
+    backgroundColor: "#ecfeff",
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#a5f3fc",
+    marginBottom: 24,
+  },
+  alertaTitulo: {
+    fontSize: 15,
+    fontWeight: "600",
+    color: "#155e75",
+    marginBottom: 6,
+  },
+  alertaTexto: {
+    fontSize: 13,
+    color: "#0e7490",
+    lineHeight: 18,
+  },
+  feedback: {
+    marginTop: 10,
+    fontSize: 13,
+    color: "#b91c1c",
+    textAlign: "center",
+  },
+  hint: {
+    marginTop: 6,
+    fontSize: 12,
+    color: "#6b7280",
+  },
+});

--- a/front/src/screens/SignUpScreen.tsx
+++ b/front/src/screens/SignUpScreen.tsx
@@ -1,0 +1,170 @@
+import React, { useState } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  TextInput,
+  TouchableOpacity,
+  ScrollView,
+  ActivityIndicator,
+} from "react-native";
+
+type Props = {
+  tenantId: string;
+  onTenantChange: (value: string) => void;
+  onSignUp: (email: string, password: string) => Promise<void>;
+  onBack: () => void;
+};
+
+export default function SignUpScreen({ tenantId, onTenantChange, onSignUp, onBack }: Props) {
+  const [email, setEmail] = useState("");
+  const [senha, setSenha] = useState("");
+  const [confirmacao, setConfirmacao] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleSignUp = async () => {
+    if (senha !== confirmacao) {
+      setMessage("As senhas nao conferem.");
+      return;
+    }
+    setLoading(true);
+    setMessage(null);
+    try {
+      await onSignUp(email, senha);
+    } catch (error) {
+      setMessage(error instanceof Error ? error.message : "Falha ao criar conta.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.header}>
+        <Text style={styles.titulo}>Criar conta</Text>
+        <Text style={styles.subtitulo}>
+          Cadastre-se com email e senha para acessar o Coach Pessoal.
+        </Text>
+      </View>
+
+      <View style={styles.card}>
+        <Text style={styles.secaoTitulo}>Dados da conta</Text>
+        <TextInput
+          style={styles.input}
+          placeholder="Tenant ID"
+          value={tenantId}
+          onChangeText={onTenantChange}
+          autoCapitalize="none"
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Email"
+          value={email}
+          onChangeText={setEmail}
+          autoCapitalize="none"
+          keyboardType="email-address"
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Senha"
+          value={senha}
+          onChangeText={setSenha}
+          secureTextEntry
+        />
+        <TextInput
+          style={styles.input}
+          placeholder="Confirmar senha"
+          value={confirmacao}
+          onChangeText={setConfirmacao}
+          secureTextEntry
+        />
+        <Text style={styles.hint}>
+          Senha minima: 8+ caracteres, 1 numero e 1 caractere especial.
+        </Text>
+        <TouchableOpacity style={styles.acaoPrimaria} onPress={handleSignUp} disabled={loading}>
+          {loading ? <ActivityIndicator color="#fff" /> : <Text style={styles.acaoPrimariaTexto}>Criar conta</Text>}
+        </TouchableOpacity>
+        {message ? <Text style={styles.feedback}>{message}</Text> : null}
+        <TouchableOpacity onPress={onBack} disabled={loading}>
+          <Text style={styles.link}>Ja tenho conta</Text>
+        </TouchableOpacity>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flexGrow: 1,
+    padding: 20,
+    backgroundColor: "#f6f7f9",
+  },
+  header: {
+    marginBottom: 20,
+  },
+  titulo: {
+    fontSize: 28,
+    fontWeight: "700",
+    color: "#264653",
+  },
+  subtitulo: {
+    fontSize: 15,
+    color: "#6b7280",
+    marginTop: 6,
+  },
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 16,
+    shadowColor: "#000",
+    shadowOpacity: 0.05,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 2,
+  },
+  secaoTitulo: {
+    fontSize: 16,
+    fontWeight: "600",
+    color: "#1f2937",
+    marginBottom: 10,
+  },
+  input: {
+    borderWidth: 1,
+    borderColor: "#d1d5db",
+    borderRadius: 8,
+    padding: 12,
+    fontSize: 15,
+    marginBottom: 10,
+    backgroundColor: "#f9fafb",
+  },
+  acaoPrimaria: {
+    backgroundColor: "#264653",
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: "center",
+    marginTop: 6,
+  },
+  acaoPrimariaTexto: {
+    color: "#fff",
+    fontWeight: "600",
+  },
+  link: {
+    marginTop: 12,
+    color: "#2563eb",
+    fontWeight: "500",
+    textAlign: "center",
+  },
+  hint: {
+    fontSize: 12,
+    color: "#6b7280",
+    marginBottom: 10,
+  },
+  feedback: {
+    marginTop: 10,
+    fontSize: 13,
+    color: "#b91c1c",
+    textAlign: "center",
+  },
+});

--- a/front/src/services/authService.ts
+++ b/front/src/services/authService.ts
@@ -1,0 +1,138 @@
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import { buildApiUrl } from "../config/api";
+
+const TOKEN_STORAGE_KEY = "auth_tokens";
+const TENANT_STORAGE_KEY = "tenant_id";
+
+type AuthTokens = {
+  accessToken: string;
+  refreshToken: string;
+  expiresAt: string;
+};
+
+export const getTenantId = async () => {
+  return AsyncStorage.getItem(TENANT_STORAGE_KEY);
+};
+
+export const setTenantId = async (tenantId: string) => {
+  await AsyncStorage.setItem(TENANT_STORAGE_KEY, tenantId);
+};
+
+export const clearTenantId = async () => {
+  await AsyncStorage.removeItem(TENANT_STORAGE_KEY);
+};
+
+export const getStoredTokens = async (): Promise<AuthTokens | null> => {
+  const raw = await AsyncStorage.getItem(TOKEN_STORAGE_KEY);
+  if (!raw) {
+    return null;
+  }
+  try {
+    return JSON.parse(raw) as AuthTokens;
+  } catch {
+    return null;
+  }
+};
+
+export const storeTokens = async (tokens: AuthTokens) => {
+  await AsyncStorage.setItem(TOKEN_STORAGE_KEY, JSON.stringify(tokens));
+};
+
+export const clearTokens = async () => {
+  await AsyncStorage.removeItem(TOKEN_STORAGE_KEY);
+};
+
+const request = async <T>(
+  path: string,
+  options: RequestInit & { tenantId: string }
+): Promise<T> => {
+  const { tenantId, ...rest } = options;
+  const response = await fetch(buildApiUrl(path), {
+    ...rest,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Tenant-ID": tenantId,
+      ...(rest.headers || {}),
+    },
+  });
+  const text = await response.text();
+  const data = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    throw new Error(data?.message || data?.error || "Erro ao processar requisicao.");
+  }
+  return data as T;
+};
+
+export const login = async (tenantId: string, email: string, password: string) => {
+  return request<AuthTokens>("/auth/login", {
+    method: "POST",
+    tenantId,
+    body: JSON.stringify({ email, password }),
+  });
+};
+
+export const register = async (tenantId: string, email: string, password: string) => {
+  return request<AuthTokens>("/auth/register", {
+    method: "POST",
+    tenantId,
+    body: JSON.stringify({ email, password }),
+  });
+};
+
+export const refreshSession = async (tenantId: string, refreshToken: string) => {
+  return request<AuthTokens>("/auth/refresh", {
+    method: "POST",
+    tenantId,
+    body: JSON.stringify({ refreshToken }),
+  });
+};
+
+export const requestPasswordReset = async (tenantId: string, email: string) => {
+  return request<{ status: string }>("/auth/password/request-reset", {
+    method: "POST",
+    tenantId,
+    body: JSON.stringify({ email }),
+  });
+};
+
+export const resetPassword = async (tenantId: string, token: string, newPassword: string) => {
+  await request<void>("/auth/password/reset", {
+    method: "POST",
+    tenantId,
+    body: JSON.stringify({ token, newPassword }),
+  });
+};
+
+export const logout = async (tenantId: string, accessToken: string) => {
+  await request<void>("/auth/logout", {
+    method: "POST",
+    tenantId,
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  await clearTokens();
+};
+
+export const fetchProviderStatus = async (tenantId: string) => {
+  return request<{ providers: { provider: string; configured: boolean; clientId: string | null }[] }>(
+    "/auth/providers",
+    {
+      method: "GET",
+      tenantId,
+    }
+  );
+};
+
+export const startSocialLogin = async (tenantId: string, provider: string, redirectUri: string) => {
+  return request<{ authUrl: string }>(`/auth/oauth/${provider}/start?redirectUri=${encodeURIComponent(redirectUri)}`, {
+    method: "GET",
+    tenantId,
+  });
+};
+
+export const completeSocialLogin = async (tenantId: string, code: string) => {
+  return request<AuthTokens>("/auth/oauth/complete", {
+    method: "POST",
+    tenantId,
+    body: JSON.stringify({ code }),
+  });
+};

--- a/front/src/services/tenantService.ts
+++ b/front/src/services/tenantService.ts
@@ -1,0 +1,51 @@
+import { buildApiUrl } from "../config/api";
+
+type OAuthConfigPayload = {
+  provider: string;
+  configured: boolean;
+  clientId: string | null;
+  secretMasked: string | null;
+  callbackUri: string | null;
+  redirectUris: string[];
+};
+
+const request = async <T>(path: string, options: RequestInit & { tenantId: string; token: string }) => {
+  const { tenantId, token, ...rest } = options;
+  const response = await fetch(buildApiUrl(path), {
+    ...rest,
+    headers: {
+      "Content-Type": "application/json",
+      "X-Tenant-ID": tenantId,
+      Authorization: `Bearer ${token}`,
+      ...(rest.headers || {}),
+    },
+  });
+  const text = await response.text();
+  const data = text ? JSON.parse(text) : null;
+  if (!response.ok) {
+    throw new Error(data?.message || data?.error || "Erro ao processar requisicao.");
+  }
+  return data as T;
+};
+
+export const fetchTenantOAuthConfigs = async (tenantId: string, token: string) => {
+  return request<OAuthConfigPayload[]>("/tenant/oauth", {
+    method: "GET",
+    tenantId,
+    token,
+  });
+};
+
+export const updateTenantOAuthConfig = async (
+  tenantId: string,
+  token: string,
+  provider: string,
+  payload: { clientId: string; clientSecret: string; callbackUri: string; redirectUris: string[] }
+) => {
+  return request<OAuthConfigPayload>(`/tenant/oauth/${provider}`, {
+    method: "PUT",
+    tenantId,
+    token,
+    body: JSON.stringify(payload),
+  });
+};


### PR DESCRIPTION
### Motivation
- Provide a full, secure multi-tenant authentication system (email/password, password reset, refresh tokens, logout) and first-class social login using per-tenant OAuth credentials for Google, Microsoft and Facebook. 
- Ensure absolute tenant isolation so no tenant can read another tenant's users, tokens, OAuth configs or events. 
- Allow tenants to manage their own OAuth credentials via an admin UI while storing secrets encrypted and never exposing clear secrets in responses. 
- Integrate tenant-awareness end-to-end (frontend, backend, DB schema and migrations) and add observability primitives for safe auditing and tracing.

### Description
- Database and migrations: add `migrations/005_auth_multi_tenant.sql` and `migrations/006_add_tenant_to_app_events.sql` to create `tenants`, `users`, `social_accounts`, `tenant_oauth_configs`, `refresh_tokens`, `password_reset_tokens`, `oauth_states`, `oauth_login_codes`, `audit_logs`, and add `tenant_id` to `app_events` for tenant-scoped events. 
- Backend (Node/Express): implement tenant-aware auth endpoints and flows in `back/src/index.ts` including `POST /tenants`, `POST /auth/register`, `POST /auth/login`, `POST /auth/refresh`, `POST /auth/logout`, `POST /auth/password/request-reset`, `POST /auth/password/reset`, `GET /auth/providers`, `GET /auth/oauth/:provider/start`, `GET /auth/oauth/:provider/callback`, `POST /auth/oauth/complete`, tenant admin endpoints `GET /tenant/oauth` and `PUT /tenant/oauth/:provider`, and social linking endpoints `POST/DELETE /auth/social/link/:provider`. All critical routes now require `X-Tenant-ID` and appropriate auth/tenant middleware. 
- Tenant OAuth and secrets: add `back/src/repositories/authRepository.ts` for tenant/user/oauth persistence and `back/src/services/oauthProviders.ts` to build provider auth URLs and exchange codes for user profiles using per-tenant credentials; provider secrets are encrypted with AES-256-GCM via `back/src/utils/crypto.ts`. 
- Security primitives: implement strong password hashing with `scrypt` in `back/src/utils/passwords.ts`, signed access tokens (HMAC-SHA256) and TTLs in `back/src/utils/tokens.ts`, refresh token hashing and rotation in `authRepository`, OAuth `state` stored in DB to prevent spoofing, `request_id` injection via `back/src/middleware/requestContext.ts`, tenant header enforcement via `back/src/middleware/tenantContext.ts`, and tenant-user match checks in `back/src/middleware/auth.ts`. 
- Calendar and event isolation: update calendar account repository and app event repository to scope queries/updates by `tenant_id` and add tenant-aware list/upsert/mark functions (`calendarAccountRepository` and `appEventRepository`). 
- Frontend (React Native): add full login and signup screens (`front/src/screens/LoginScreen.tsx`, `front/src/screens/SignUpScreen.tsx`) with tenant ID input, social login buttons gated by tenant config, password reset flows, and tenant OAuth admin UI within `ConfigScreen` to let tenant admins configure per-provider `clientId`, `clientSecret` (masked after save), `callbackUri` and redirect URIs; new services `front/src/services/authService.ts` and `front/src/services/tenantService.ts` call the backend and persist tokens/tenant in `AsyncStorage`. 
- Observability & audit: audit log entries for register/login/password reset/tenant oauth updates, and `x-request-id` propagated to responses; sensitive values (passwords, tokens, secrets) are never logged in full. 
- Docs: updated backend README with setup, env variables (`AUTH_JWT_SECRET`, `AUTH_ENCRYPTION_KEY`), migration steps, endpoints and security decisions (`back/README.md`).

### Testing
- No automated tests were executed against the new code in this rollout. 
- An attempt to install backend dependencies with `npm install` was performed but failed due to registry access returning HTTP 403, so test runs (unit/integration) were not possible in this environment. 
- Manual code verification: compilation / static edits were applied and the server code was updated and committed, but full local runtime or CI test execution was not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983b422c4bc832f9e15f9aeb9a189e5)